### PR TITLE
Add unit tests for core modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,12 @@ lazy val root = (project in file("."))
     // Spark 4 requires Java 17+
     javacOptions ++= Seq("-source", "17", "-target", "17"),
 
+    // Arrow requires --add-opens on Java 17+
+    Test / javaOptions ++= Seq(
+      "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    ),
+    Test / fork := true,
+
     // Assembly settings to avoid conflicts
     assembly / assemblyMergeStrategy := {
       case PathList("META-INF", _*) => MergeStrategy.discard

--- a/src/main/scala/com/apilytics/core/http/Client.scala
+++ b/src/main/scala/com/apilytics/core/http/Client.scala
@@ -30,7 +30,7 @@ object Client {
       .map(new RestClient(_, httpConfig, authConfig))
   }
 
-  final class RestClient(
+  class RestClient(
       underlying: Http4sClient[IO],
       httpConfig: HttpConfig,
       authConfig: AuthConfig

--- a/src/test/scala/com/apilytics/core/arrow/ConverterSuite.scala
+++ b/src/test/scala/com/apilytics/core/arrow/ConverterSuite.scala
@@ -1,0 +1,152 @@
+package com.apilytics.core.arrow
+
+import com.apilytics.core.openapi.OpenAPISchema
+import com.apilytics.core.schema.SchemaMapper
+import io.circe.Json
+import io.circe.parser._
+import munit.FunSuite
+import org.apache.arrow.memory.RootAllocator
+
+import java.nio.charset.StandardCharsets
+import scala.jdk.CollectionConverters._
+
+class ConverterSuite extends FunSuite {
+
+  private val allocator = new RootAllocator()
+
+  override def afterAll(): Unit = allocator.close()
+
+  test("extractRecords with no dataPath returns top-level array") {
+    val json = parse("""[{"id": 1}, {"id": 2}]""").toOption.get
+    val records = Converter.extractRecords(json, None)
+    assertEquals(records.size, 2)
+  }
+
+  test("extractRecords with no dataPath and single object returns it as list") {
+    val json = parse("""{"id": 1}""").toOption.get
+    val records = Converter.extractRecords(json, None)
+    assertEquals(records.size, 1)
+  }
+
+  test("extractRecords with dataPath extracts nested array") {
+    val json = parse("""{"data": [{"id": 1}, {"id": 2}], "meta": {}}""").toOption.get
+    val records = Converter.extractRecords(json, Some("/data"))
+    assertEquals(records.size, 2)
+  }
+
+  test("extractRecords with invalid pointer throws") {
+    val json = Json.obj()
+    intercept[IllegalArgumentException] {
+      Converter.extractRecords(json, Some("not a pointer"))
+    }
+  }
+
+  test("extractRecords with missing path returns empty") {
+    val json = parse("""{"other": [1, 2]}""").toOption.get
+    val records = Converter.extractRecords(json, Some("/data"))
+    assertEquals(records.size, 0)
+  }
+
+  test("toArrow converts string fields") {
+    val schema = SchemaMapper.toArrowSchema(
+      OpenAPISchema.ObjectType(Map("name" -> OpenAPISchema.StringType()), Set("name"))
+    )
+    val records = List(
+      parse("""{"name": "Alice"}""").toOption.get,
+      parse("""{"name": "Bob"}""").toOption.get
+    )
+
+    val root = Converter.toArrow(records, schema, allocator)
+    try {
+      assertEquals(root.getRowCount, 2)
+      val vec = root.getVector("name").asInstanceOf[org.apache.arrow.vector.VarCharVector]
+      assertEquals(new String(vec.get(0), StandardCharsets.UTF_8), "Alice")
+      assertEquals(new String(vec.get(1), StandardCharsets.UTF_8), "Bob")
+    } finally root.close()
+  }
+
+  test("toArrow converts integer fields") {
+    val schema = SchemaMapper.toArrowSchema(
+      OpenAPISchema.ObjectType(Map("count" -> OpenAPISchema.IntegerType()))
+    )
+    val records = List(parse("""{"count": 42}""").toOption.get)
+
+    val root = Converter.toArrow(records, schema, allocator)
+    try {
+      val vec = root.getVector("count").asInstanceOf[org.apache.arrow.vector.IntVector]
+      assertEquals(vec.get(0), 42)
+    } finally root.close()
+  }
+
+  test("toArrow converts boolean fields") {
+    val schema = SchemaMapper.toArrowSchema(
+      OpenAPISchema.ObjectType(Map("active" -> OpenAPISchema.BooleanType))
+    )
+    val records = List(
+      parse("""{"active": true}""").toOption.get,
+      parse("""{"active": false}""").toOption.get
+    )
+
+    val root = Converter.toArrow(records, schema, allocator)
+    try {
+      val vec = root.getVector("active").asInstanceOf[org.apache.arrow.vector.BitVector]
+      assertEquals(vec.get(0), 1)
+      assertEquals(vec.get(1), 0)
+    } finally root.close()
+  }
+
+  test("toArrow handles null values") {
+    val schema = SchemaMapper.toArrowSchema(
+      OpenAPISchema.ObjectType(Map("name" -> OpenAPISchema.StringType()))
+    )
+    val records = List(parse("""{"name": null}""").toOption.get)
+
+    val root = Converter.toArrow(records, schema, allocator)
+    try {
+      val vec = root.getVector("name").asInstanceOf[org.apache.arrow.vector.VarCharVector]
+      assert(vec.isNull(0))
+    } finally root.close()
+  }
+
+  test("toArrow navigates nested fields via json path metadata") {
+    val schema = SchemaMapper.toArrowSchema(
+      OpenAPISchema.ObjectType(Map(
+        "address" -> OpenAPISchema.ObjectType(Map("city" -> OpenAPISchema.StringType()))
+      ))
+    )
+    val records = List(parse("""{"address": {"city": "NYC"}}""").toOption.get)
+
+    val root = Converter.toArrow(records, schema, allocator)
+    try {
+      val vec = root.getVector("address_city").asInstanceOf[org.apache.arrow.vector.VarCharVector]
+      assertEquals(new String(vec.get(0), StandardCharsets.UTF_8), "NYC")
+    } finally root.close()
+  }
+
+  test("toArrow converts float fields") {
+    val schema = SchemaMapper.toArrowSchema(
+      OpenAPISchema.ObjectType(Map("score" -> OpenAPISchema.NumberType()))
+    )
+    val records = List(parse("""{"score": 3.14}""").toOption.get)
+
+    val root = Converter.toArrow(records, schema, allocator)
+    try {
+      val vec = root.getVector("score").asInstanceOf[org.apache.arrow.vector.Float8Vector]
+      assertEquals(vec.get(0), 3.14, 0.001)
+    } finally root.close()
+  }
+
+  test("toArrow serializes arrays as JSON strings") {
+    val schema = SchemaMapper.toArrowSchema(
+      OpenAPISchema.ObjectType(Map("tags" -> OpenAPISchema.ArrayType(OpenAPISchema.StringType())))
+    )
+    val records = List(parse("""{"tags": ["a", "b"]}""").toOption.get)
+
+    val root = Converter.toArrow(records, schema, allocator)
+    try {
+      val vec = root.getVector("tags").asInstanceOf[org.apache.arrow.vector.VarCharVector]
+      val value = new String(vec.get(0), StandardCharsets.UTF_8)
+      assertEquals(value, """["a","b"]""")
+    } finally root.close()
+  }
+}

--- a/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
+++ b/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
@@ -1,0 +1,119 @@
+package com.apilytics.core.config
+
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+
+class LoaderSuite extends FunSuite {
+
+  test("load minimal config with bearer auth") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "https://example.com/openapi.json"
+        |auth {
+        |  type = bearer
+        |  token = "abc123"
+        |}
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    assertEquals(result.openapi, "https://example.com/openapi.json")
+    assertEquals(result.auth.authType, AuthType.Bearer)
+    assertEquals(result.auth.token, Some("abc123"))
+    assertEquals(result.pagination.style, PaginationStyle.None)
+    assertEquals(result.schema.flattenDepth, 2)
+  }
+
+  test("load full config with all sections") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth {
+        |  type = basic
+        |  username = "user"
+        |  password = "pass"
+        |}
+        |pagination {
+        |  style = cursor
+        |  cursor-path = "/meta/next_cursor"
+        |  cursor-param = "cursor"
+        |  page-size-param = "per_page"
+        |  max-page-size = 50
+        |}
+        |schema {
+        |  flatten-depth = 3
+        |  array-handling = explode_view
+        |}
+        |http {
+        |  max-retries = 3
+        |  max-backoff = "10 seconds"
+        |  timeout = "5 seconds"
+        |}
+        |tables {
+        |  users {
+        |    endpoint = "/users"
+        |    data-path = "/data"
+        |    filters = [
+        |      { param = "email", column = "email", operators = ["eq"] }
+        |    ]
+        |  }
+        |}
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    assertEquals(result.auth.authType, AuthType.Basic)
+    assertEquals(result.auth.username, Some("user"))
+    assertEquals(result.pagination.style, PaginationStyle.Cursor)
+    assertEquals(result.pagination.maxPageSize, 50)
+    assertEquals(result.schema.flattenDepth, 3)
+    assertEquals(result.schema.arrayHandling, ArrayHandling.ExplodeView)
+    assertEquals(result.http.maxRetries, 3)
+    assertEquals(result.tables.size, 1)
+    val users = result.tables("users")
+    assertEquals(users.endpoint, "/users")
+    assertEquals(users.dataPath, Some("/data"))
+    assertEquals(users.filters.size, 1)
+    assertEquals(users.filters.head.param, "email")
+  }
+
+  test("unknown auth type throws") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = "magic" }
+        |""".stripMargin)
+
+    intercept[IllegalArgumentException] {
+      Loader.load(config)
+    }
+  }
+
+  test("header auth config") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth {
+        |  type = header
+        |  header-name = "X-Api-Key"
+        |  header-value = "secret"
+        |}
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    assertEquals(result.auth.authType, AuthType.Header)
+    assertEquals(result.auth.headerName, Some("X-Api-Key"))
+    assertEquals(result.auth.headerValue, Some("secret"))
+  }
+
+  test("all pagination styles parse correctly") {
+    def withStyle(style: String) = ConfigFactory.parseString(
+      s"""
+         |openapi = "spec.json"
+         |auth { type = bearer, token = "t" }
+         |pagination { style = $style }
+         |""".stripMargin)
+
+    assertEquals(Loader.load(withStyle("offset")).pagination.style, PaginationStyle.Offset)
+    assertEquals(Loader.load(withStyle("link_header")).pagination.style, PaginationStyle.LinkHeader)
+    assertEquals(Loader.load(withStyle("none")).pagination.style, PaginationStyle.None)
+  }
+}

--- a/src/test/scala/com/apilytics/core/http/AuthSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/AuthSuite.scala
@@ -1,0 +1,60 @@
+package com.apilytics.core.http
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.apilytics.core.config.{AuthConfig, AuthType}
+import munit.FunSuite
+import org.http4s.Request
+
+class AuthSuite extends FunSuite {
+
+  private def applyAuth(config: AuthConfig): Request[IO] = {
+    val f = Auth(config)
+    f(Request[IO]()).unsafeRunSync()
+  }
+
+  test("bearer auth adds Authorization header") {
+    val config = AuthConfig(authType = AuthType.Bearer, token = Some("mytoken"))
+    val req = applyAuth(config)
+    val header = req.headers.get(org.typelevel.ci.CIString("Authorization")).get.head.value
+    assert(header.contains("Bearer"))
+    assert(header.contains("mytoken"))
+  }
+
+  test("basic auth adds base64 encoded header") {
+    val config = AuthConfig(authType = AuthType.Basic, username = Some("user"), password = Some("pass"))
+    val req = applyAuth(config)
+    val header = req.headers.get(org.typelevel.ci.CIString("Authorization")).get.head.value
+    assert(header.contains("Basic"))
+    val encoded = java.util.Base64.getEncoder.encodeToString("user:pass".getBytes("UTF-8"))
+    assert(header.contains(encoded))
+  }
+
+  test("header auth adds custom header") {
+    val config = AuthConfig(authType = AuthType.Header, headerName = Some("X-Api-Key"), headerValue = Some("secret"))
+    val req = applyAuth(config)
+    val header = req.headers.get(org.typelevel.ci.CIString("X-Api-Key")).get.head.value
+    assertEquals(header, "secret")
+  }
+
+  test("bearer auth without token throws") {
+    val config = AuthConfig(authType = AuthType.Bearer)
+    intercept[IllegalArgumentException] {
+      Auth(config)
+    }
+  }
+
+  test("basic auth without username throws") {
+    val config = AuthConfig(authType = AuthType.Basic, password = Some("pass"))
+    intercept[IllegalArgumentException] {
+      Auth(config)
+    }
+  }
+
+  test("header auth without header-name throws") {
+    val config = AuthConfig(authType = AuthType.Header, headerValue = Some("val"))
+    intercept[IllegalArgumentException] {
+      Auth(config)
+    }
+  }
+}

--- a/src/test/scala/com/apilytics/core/http/PaginatorSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/PaginatorSuite.scala
@@ -1,0 +1,90 @@
+package com.apilytics.core.http
+
+import cats.effect.IO
+import com.apilytics.core.config.{AuthConfig, AuthType, HttpConfig, PaginationConfig, PaginationStyle}
+import io.circe.Json
+import io.circe.parser._
+import munit.CatsEffectSuite
+import org.http4s.Uri
+
+import scala.concurrent.duration._
+
+class PaginatorSuite extends CatsEffectSuite {
+
+  private val dummyAuth = AuthConfig(authType = AuthType.Bearer, token = Some("test"))
+  private val dummyHttp = HttpConfig(maxRetries = 0, maxBackoff = 1.second, timeout = 1.second)
+
+  private def mockClient(responses: List[(Json, Map[String, String])]): Client.RestClient = {
+    var callIndex = 0
+    new Client.RestClient(null, dummyHttp, dummyAuth) {
+      override def get(uri: Uri, params: Map[String, String]): IO[ApiResponse] = IO {
+        val (json, headers) = responses(callIndex)
+        callIndex += 1
+        ApiResponse(json, 200, headers)
+      }
+    }
+  }
+
+  test("single page (no pagination) returns one result") {
+    val json = parse("""[{"id": 1}]""").toOption.get
+    val client = mockClient(List((json, Map.empty)))
+    val config = PaginationConfig(style = PaginationStyle.None)
+
+    Paginator.pages(client, Uri.unsafeFromString("http://test"), Map.empty, config)
+      .compile.toList.map { pages =>
+        assertEquals(pages.size, 1)
+        assertEquals(pages.head, json)
+      }
+  }
+
+  test("cursor pagination follows cursor until empty") {
+    val page1 = parse("""{"items": [1,2], "cursor": "abc"}""").toOption.get
+    val page2 = parse("""{"items": [3], "cursor": ""}""").toOption.get
+    val client = mockClient(List((page1, Map.empty), (page2, Map.empty)))
+
+    val config = PaginationConfig(
+      style = PaginationStyle.Cursor,
+      cursorPath = Some("/cursor"),
+      cursorParam = Some("cursor"),
+      maxPageSize = 100
+    )
+
+    Paginator.pages(client, Uri.unsafeFromString("http://test"), Map.empty, config)
+      .compile.toList.map { pages =>
+        assertEquals(pages.size, 2)
+      }
+  }
+
+  test("link header pagination follows next link") {
+    val page1 = parse("""{"data": [1]}""").toOption.get
+    val page2 = parse("""{"data": [2]}""").toOption.get
+    val client = mockClient(List(
+      (page1, Map("Link" -> """<http://test?page=2>; rel="next"""")),
+      (page2, Map.empty)
+    ))
+
+    val config = PaginationConfig(style = PaginationStyle.LinkHeader, maxPageSize = 100)
+
+    Paginator.pages(client, Uri.unsafeFromString("http://test"), Map.empty, config)
+      .compile.toList.map { pages =>
+        assertEquals(pages.size, 2)
+      }
+  }
+
+  test("limit caps number of pages") {
+    val page = parse("""{"items": [1]}""").toOption.get
+    val client = mockClient(List.fill(10)((page, Map.empty)))
+
+    val config = PaginationConfig(
+      style = PaginationStyle.Offset,
+      offsetParam = Some("offset"),
+      pageSizeParam = Some("limit"),
+      maxPageSize = 10
+    )
+
+    Paginator.pages(client, Uri.unsafeFromString("http://test"), Map.empty, config, limit = Some(5))
+      .compile.toList.map { pages =>
+        assertEquals(pages.size, 1)
+      }
+  }
+}

--- a/src/test/scala/com/apilytics/core/openapi/ParserSuite.scala
+++ b/src/test/scala/com/apilytics/core/openapi/ParserSuite.scala
@@ -1,0 +1,152 @@
+package com.apilytics.core.openapi
+
+import munit.FunSuite
+
+class ParserSuite extends FunSuite {
+
+  private val simpleSpec =
+    """{
+      |  "openapi": "3.0.0",
+      |  "info": { "title": "Test", "version": "1.0" },
+      |  "servers": [{ "url": "https://api.example.com" }],
+      |  "paths": {
+      |    "/users": {
+      |      "get": {
+      |        "operationId": "listUsers",
+      |        "parameters": [
+      |          { "name": "page", "in": "query", "schema": { "type": "integer" }, "required": false },
+      |          { "name": "email", "in": "query", "schema": { "type": "string" }, "required": true }
+      |        ],
+      |        "responses": {
+      |          "200": {
+      |            "content": {
+      |              "application/json": {
+      |                "schema": {
+      |                  "type": "object",
+      |                  "required": ["id", "name"],
+      |                  "properties": {
+      |                    "id": { "type": "integer", "format": "int64" },
+      |                    "name": { "type": "string" },
+      |                    "email": { "type": "string" },
+      |                    "active": { "type": "boolean" }
+      |                  }
+      |                }
+      |              }
+      |            }
+      |          }
+      |        }
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+
+  test("parse simple spec extracts endpoint") {
+    val result = Parser.parseContent(simpleSpec)
+    assertEquals(result.baseUrl, "https://api.example.com")
+    assertEquals(result.endpoints.size, 1)
+
+    val ep = result.endpoints.head
+    assertEquals(ep.path, "/users")
+    assertEquals(ep.operationId, Some("listUsers"))
+  }
+
+  test("parse extracts query params") {
+    val result = Parser.parseContent(simpleSpec)
+    val ep = result.endpoints.head
+    assertEquals(ep.queryParams.size, 2)
+
+    val emailParam = ep.queryParams.find(_.name == "email").get
+    assert(emailParam.required)
+    assert(emailParam.schema.isInstanceOf[OpenAPISchema.StringType])
+
+    val pageParam = ep.queryParams.find(_.name == "page").get
+    assert(!pageParam.required)
+  }
+
+  test("parse extracts schema types") {
+    val result = Parser.parseContent(simpleSpec)
+    val props = result.endpoints.head.responseSchema.properties
+
+    assert(props("id").isInstanceOf[OpenAPISchema.IntegerType])
+    assertEquals(props("id").asInstanceOf[OpenAPISchema.IntegerType].format, Some("int64"))
+    assert(props("name").isInstanceOf[OpenAPISchema.StringType])
+    assertEquals(props("active"), OpenAPISchema.BooleanType)
+  }
+
+  test("parse extracts required fields") {
+    val result = Parser.parseContent(simpleSpec)
+    val required = result.endpoints.head.responseSchema.required
+    assert(required.contains("id"))
+    assert(required.contains("name"))
+    assert(!required.contains("email"))
+  }
+
+  test("array response gets wrapped in data key") {
+    val arraySpec =
+      """{
+        |  "openapi": "3.0.0",
+        |  "info": { "title": "Test", "version": "1.0" },
+        |  "paths": {
+        |    "/items": {
+        |      "get": {
+        |        "responses": {
+        |          "200": {
+        |            "content": {
+        |              "application/json": {
+        |                "schema": {
+        |                  "type": "array",
+        |                  "items": {
+        |                    "type": "object",
+        |                    "properties": {
+        |                      "id": { "type": "integer" }
+        |                    }
+        |                  }
+        |                }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val result = Parser.parseContent(arraySpec)
+    assertEquals(result.endpoints.size, 1)
+    val schema = result.endpoints.head.responseSchema
+    assert(schema.properties.contains("data"))
+    assert(schema.properties("data").isInstanceOf[OpenAPISchema.ArrayType])
+  }
+
+  test("POST-only endpoint is skipped") {
+    val postSpec =
+      """{
+        |  "openapi": "3.0.0",
+        |  "info": { "title": "Test", "version": "1.0" },
+        |  "paths": {
+        |    "/create": {
+        |      "post": {
+        |        "responses": {
+        |          "200": {
+        |            "content": {
+        |              "application/json": {
+        |                "schema": { "type": "object", "properties": { "id": { "type": "integer" } } }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val result = Parser.parseContent(postSpec)
+    assertEquals(result.endpoints.size, 0)
+  }
+
+  test("invalid spec throws") {
+    intercept[IllegalArgumentException] {
+      Parser.parseContent("not valid json at all {{{")
+    }
+  }
+}

--- a/src/test/scala/com/apilytics/core/schema/SchemaMapperSuite.scala
+++ b/src/test/scala/com/apilytics/core/schema/SchemaMapperSuite.scala
@@ -1,0 +1,135 @@
+package com.apilytics.core.schema
+
+import com.apilytics.core.openapi.OpenAPISchema
+import munit.FunSuite
+import org.apache.arrow.vector.types.pojo.ArrowType
+
+import scala.jdk.CollectionConverters._
+
+class SchemaMapperSuite extends FunSuite {
+
+  test("flat object maps to correct Arrow types") {
+    val schema = OpenAPISchema.ObjectType(
+      Map(
+        "name" -> OpenAPISchema.StringType(),
+        "age" -> OpenAPISchema.IntegerType(),
+        "score" -> OpenAPISchema.NumberType(),
+        "active" -> OpenAPISchema.BooleanType
+      ),
+      required = Set("name")
+    )
+
+    val arrow = SchemaMapper.toArrowSchema(schema)
+    val fields = arrow.getFields.asScala.toList
+    assertEquals(fields.size, 4)
+
+    val nameField = fields.find(_.getName == "name").get
+    assert(nameField.getType.isInstanceOf[ArrowType.Utf8])
+    assert(!nameField.isNullable)
+
+    val ageField = fields.find(_.getName == "age").get
+    assert(ageField.getType.isInstanceOf[ArrowType.Int])
+    assertEquals(ageField.getType.asInstanceOf[ArrowType.Int].getBitWidth, 32)
+    assert(ageField.isNullable)
+
+    val scoreField = fields.find(_.getName == "score").get
+    assert(scoreField.getType.isInstanceOf[ArrowType.FloatingPoint])
+
+    val activeField = fields.find(_.getName == "active").get
+    assert(activeField.getType.isInstanceOf[ArrowType.Bool])
+  }
+
+  test("nested object flattens with underscore naming") {
+    val schema = OpenAPISchema.ObjectType(
+      Map(
+        "id" -> OpenAPISchema.IntegerType(),
+        "address" -> OpenAPISchema.ObjectType(
+          Map(
+            "city" -> OpenAPISchema.StringType(),
+            "zip" -> OpenAPISchema.StringType()
+          )
+        )
+      )
+    )
+
+    val arrow = SchemaMapper.toArrowSchema(schema, maxDepth = 2)
+    val names = arrow.getFields.asScala.map(_.getName).toSet
+    assert(names.contains("address_city"))
+    assert(names.contains("address_zip"))
+    assert(names.contains("id"))
+  }
+
+  test("json path metadata is set correctly for nested fields") {
+    val schema = OpenAPISchema.ObjectType(
+      Map(
+        "address" -> OpenAPISchema.ObjectType(
+          Map("city" -> OpenAPISchema.StringType())
+        )
+      )
+    )
+
+    val arrow = SchemaMapper.toArrowSchema(schema)
+    val cityField = arrow.getFields.asScala.find(_.getName == "address_city").get
+    val jsonPath = cityField.getMetadata.get(SchemaMapper.JsonPathKey)
+    assertEquals(jsonPath, "address,city")
+  }
+
+  test("beyond maxDepth objects become VARCHAR") {
+    val schema = OpenAPISchema.ObjectType(
+      Map(
+        "deep" -> OpenAPISchema.ObjectType(
+          Map(
+            "nested" -> OpenAPISchema.ObjectType(
+              Map("value" -> OpenAPISchema.StringType())
+            )
+          )
+        )
+      )
+    )
+
+    // maxDepth=1 means only one level of flattening
+    val arrow = SchemaMapper.toArrowSchema(schema, maxDepth = 1)
+    val fields = arrow.getFields.asScala.toList
+    val nestedField = fields.find(_.getName == "deep_nested").get
+    assert(nestedField.getType.isInstanceOf[ArrowType.Utf8])
+  }
+
+  test("array fields become VARCHAR") {
+    val schema = OpenAPISchema.ObjectType(
+      Map("tags" -> OpenAPISchema.ArrayType(OpenAPISchema.StringType()))
+    )
+
+    val arrow = SchemaMapper.toArrowSchema(schema)
+    val field = arrow.getFields.asScala.head
+    assertEquals(field.getName, "tags")
+    assert(field.getType.isInstanceOf[ArrowType.Utf8])
+  }
+
+  test("date and datetime formats map correctly") {
+    val schema = OpenAPISchema.ObjectType(
+      Map(
+        "birthday" -> OpenAPISchema.StringType(Some("date")),
+        "created_at" -> OpenAPISchema.StringType(Some("date-time"))
+      )
+    )
+
+    val arrow = SchemaMapper.toArrowSchema(schema)
+    val fields = arrow.getFields.asScala.toList
+
+    val birthday = fields.find(_.getName == "birthday").get
+    assert(birthday.getType.isInstanceOf[ArrowType.Date])
+
+    val createdAt = fields.find(_.getName == "created_at").get
+    assert(createdAt.getType.isInstanceOf[ArrowType.Timestamp])
+  }
+
+  test("int64 format maps to 64-bit int") {
+    val schema = OpenAPISchema.ObjectType(
+      Map("big_id" -> OpenAPISchema.IntegerType(Some("int64")))
+    )
+
+    val arrow = SchemaMapper.toArrowSchema(schema)
+    val field = arrow.getFields.asScala.head
+    assertEquals(field.getType.asInstanceOf[ArrowType.Int].getBitWidth, 64)
+  }
+}


### PR DESCRIPTION
## Issue
Closes #9

## Summary
- 6 test suites covering all core modules: Loader, Parser, SchemaMapper, Converter, Auth, Paginator
- 41 tests total, all passing
- Arrow `--add-opens` JVM flag for Java 17+ test compatibility
- `RestClient` made non-final for test mocking

## Test plan
- [x] `sbt test` passes (41/41)