### PR TITLE
Detect and error on schema flattening name collisions

### DIFF
--- a/src/main/scala/com/apilytics/core/schema/SchemaMapper.scala
+++ b/src/main/scala/com/apilytics/core/schema/SchemaMapper.scala
@@ -15,6 +15,13 @@ object SchemaMapper {
   /** Convert an OpenAPI object schema to an Arrow Schema, flattening nested objects up to `maxDepth`. */
   def toArrowSchema(obj: OpenAPISchema.ObjectType, maxDepth: Int = 2): Schema = {
     val fields = flattenFields(obj.properties, obj.required, prefix = "", pathSegments = Nil, depth = 0, maxDepth = maxDepth)
+    val duplicates = fields.groupBy(_.getName).collect { case (name, fs) if fs.size > 1 => name }
+    if (duplicates.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"Schema flattening produced duplicate field names: ${duplicates.mkString(", ")}. " +
+          "This happens when a top-level field name collides with a flattened nested path (e.g. 'user_name' vs 'user.name')."
+      )
+    }
     new Schema(fields.asJava)
   }
 

--- a/src/test/scala/com/apilytics/core/schema/SchemaMapperSuite.scala
+++ b/src/test/scala/com/apilytics/core/schema/SchemaMapperSuite.scala
@@ -123,6 +123,21 @@ class SchemaMapperSuite extends FunSuite {
     assert(createdAt.getType.isInstanceOf[ArrowType.Timestamp])
   }
 
+  test("flattening collision throws IllegalArgumentException") {
+    val schema = OpenAPISchema.ObjectType(
+      Map(
+        "user_name" -> OpenAPISchema.StringType(),
+        "user" -> OpenAPISchema.ObjectType(
+          Map("name" -> OpenAPISchema.StringType())
+        )
+      )
+    )
+
+    intercept[IllegalArgumentException] {
+      SchemaMapper.toArrowSchema(schema)
+    }
+  }
+
   test("int64 format maps to 64-bit int") {
     val schema = OpenAPISchema.ObjectType(
       Map("big_id" -> OpenAPISchema.IntegerType(Some("int64")))


### PR DESCRIPTION
Issue: Closes #24

## Summary
- After flattening nested objects, check for duplicate Arrow field names
- Throws IllegalArgumentException with clear message identifying the colliding names
- Example: top-level `user_name` collides with flattened `user.name`

## Test plan
- [x] New test: collision between `user_name` and `user.name` throws
- [x] All 42 tests pass