### PR TITLE
OAuth2 client credentials flow

### DIFF
--- a/src/main/scala/com/apilytics/core/http/Auth.scala
+++ b/src/main/scala/com/apilytics/core/http/Auth.scala
@@ -9,7 +9,7 @@ import org.typelevel.ci.CIString
 
 object Auth {
 
-  /** Apply auth to a request based on config. */
+  /** Apply auth to a request based on config. For OAuth2, use withTokenManager instead. */
   def apply(config: AuthConfig): Request[IO] => IO[Request[IO]] = config.authType match {
     case AuthType.Bearer =>
       val token = config.token.getOrElse(throw new IllegalArgumentException("Bearer auth requires token"))
@@ -27,9 +27,17 @@ object Auth {
       req => IO.pure(req.putHeaders(Header.Raw(CIString(name), value)))
 
     case AuthType.OAuth2Client =>
+      // Static token fallback (for pre-fetched tokens)
       val token = config.token.getOrElse(
-        throw new IllegalArgumentException("OAuth2 client credentials requires token or token-url")
+        throw new IllegalArgumentException("OAuth2 client credentials requires token-url or pre-fetched token")
       )
       req => IO.pure(req.putHeaders(Authorization(Credentials.Token(CIString("Bearer"), token))))
+  }
+
+  /** Apply OAuth2 auth using a token manager for dynamic token refresh. */
+  def withTokenManager(tokenManager: OAuth2TokenManager): Request[IO] => IO[Request[IO]] = { req =>
+    tokenManager.getToken.map { token =>
+      req.putHeaders(Authorization(Credentials.Token(CIString("Bearer"), token)))
+    }
   }
 }

--- a/src/main/scala/com/apilytics/core/http/Client.scala
+++ b/src/main/scala/com/apilytics/core/http/Client.scala
@@ -27,15 +27,40 @@ object Client {
       .default[IO]
       .withTimeout(httpConfig.timeout)
       .build
-      .map(new RestClient(_, httpConfig, authConfig))
+      .map(new RestClient(_, httpConfig, authConfig, None))
+  }
+
+  /** Create a client with OAuth2 token manager for dynamic token refresh. */
+  def resourceWithOAuth2(
+      httpConfig: HttpConfig,
+      authConfig: AuthConfig
+  ): Resource[IO, RestClient] = {
+    val clientId = authConfig.clientId.getOrElse(
+      throw new IllegalArgumentException("OAuth2 client credentials requires client-id")
+    )
+    val clientSecret = authConfig.clientSecret.getOrElse(
+      throw new IllegalArgumentException("OAuth2 client credentials requires client-secret")
+    )
+    val tokenUrl = authConfig.tokenUrl.getOrElse(
+      throw new IllegalArgumentException("OAuth2 client credentials requires token-url")
+    )
+
+    for {
+      httpClient <- EmberClientBuilder.default[IO].withTimeout(httpConfig.timeout).build
+      tokenManager <- Resource.eval(OAuth2TokenManager(clientId, clientSecret, tokenUrl, httpClient))
+    } yield new RestClient(httpClient, httpConfig, authConfig, Some(tokenManager))
   }
 
   class RestClient(
       underlying: Http4sClient[IO],
       httpConfig: HttpConfig,
-      authConfig: AuthConfig
+      authConfig: AuthConfig,
+      tokenManager: Option[OAuth2TokenManager]
   ) {
-    private val applyAuth = Auth(authConfig)
+    private val applyAuth: Request[IO] => IO[Request[IO]] = tokenManager match {
+      case Some(tm) => Auth.withTokenManager(tm)
+      case None     => Auth(authConfig)
+    }
 
     def get(uri: Uri, params: Map[String, String] = Map.empty): IO[ApiResponse] = {
       val fullUri = params.foldLeft(uri) { case (u, (k, v)) =>
@@ -44,11 +69,16 @@ object Client {
       val baseReq = Request[IO](uri = fullUri)
 
       applyAuth(baseReq).flatMap { req =>
-        executeWithRetry(req, attempt = 0)
+        executeWithRetry(req, baseReq, attempt = 0, authRetried = false)
       }
     }
 
-    private def executeWithRetry(req: Request[IO], attempt: Int): IO[ApiResponse] = {
+    private def executeWithRetry(
+        req: Request[IO],
+        baseReq: Request[IO],
+        attempt: Int,
+        authRetried: Boolean
+    ): IO[ApiResponse] = {
       underlying.run(req).use { resp =>
         val hdrs = resp.headers.headers.map(h => h.name.toString -> h.value).toMap
 
@@ -68,15 +98,24 @@ object Client {
             }
             val delay = retryAfter.getOrElse(exponentialBackoff(attempt))
             // Drain response body before retry
-            resp.body.compile.drain *> IO.sleep(delay) *> executeWithRetry(req, attempt + 1)
+            resp.body.compile.drain *> IO.sleep(delay) *> executeWithRetry(req, baseReq, attempt + 1, authRetried)
 
           case code if code >= 500 && attempt < httpConfig.maxRetries =>
             val delay = exponentialBackoff(attempt)
-            resp.body.compile.drain *> IO.sleep(delay) *> executeWithRetry(req, attempt + 1)
+            resp.body.compile.drain *> IO.sleep(delay) *> executeWithRetry(req, baseReq, attempt + 1, authRetried)
+
+          case 401 if !authRetried && tokenManager.isDefined =>
+            // Token may have expired - refresh once and retry
+            resp.body.compile.drain *>
+              tokenManager.get.refreshToken.flatMap { _ =>
+                applyAuth(baseReq).flatMap { newReq =>
+                  executeWithRetry(newReq, baseReq, attempt, authRetried = true)
+                }
+              }
 
           case 401 | 403 =>
             resp.as[String].flatMap { body =>
-              IO.raiseError(new RuntimeException(s"Auth failed (${ resp.status.code}): $body"))
+              IO.raiseError(new RuntimeException(s"Auth failed (${resp.status.code}): $body"))
             }
 
           case code =>

--- a/src/main/scala/com/apilytics/core/http/OAuth2TokenManager.scala
+++ b/src/main/scala/com/apilytics/core/http/OAuth2TokenManager.scala
@@ -1,0 +1,119 @@
+package com.apilytics.core.http
+
+import cats.effect.{IO, Ref, Resource}
+import cats.effect.std.Semaphore
+import io.circe.Json
+import org.http4s.{Method, Request, Uri, UrlForm}
+import org.http4s.circe._
+import org.http4s.client.{Client => Http4sClient}
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.headers.`Content-Type`
+import org.http4s.MediaType
+
+import java.time.Instant
+import scala.concurrent.duration._
+
+/** Manages OAuth2 client credentials token lifecycle: fetch, cache, and refresh. */
+class OAuth2TokenManager private (
+    clientId: String,
+    clientSecret: String,
+    tokenUrl: Uri,
+    httpClient: Http4sClient[IO],
+    tokenRef: Ref[IO, Option[OAuth2TokenManager.CachedToken]],
+    refreshLock: Semaphore[IO]
+) {
+
+  import OAuth2TokenManager._
+
+  /** Get a valid access token, fetching or refreshing as needed. */
+  def getToken: IO[String] = {
+    tokenRef.get.flatMap {
+      case Some(cached) if !cached.isExpired =>
+        IO.pure(cached.accessToken)
+      case _ =>
+        refreshToken
+    }
+  }
+
+  /** Force refresh the token. Used on 401 response.
+    * Invalidates current token and fetches a new one.
+    */
+  def refreshToken: IO[String] = {
+    // Use semaphore to prevent concurrent refresh attempts
+    refreshLock.permit.use { _ =>
+      // Always invalidate and fetch on forced refresh (401 means server rejected the token)
+      tokenRef.set(None) *> fetchNewToken
+    }
+  }
+
+  private def fetchNewToken: IO[String] = {
+    val formData = UrlForm(
+      "grant_type" -> "client_credentials",
+      "client_id" -> clientId,
+      "client_secret" -> clientSecret
+    )
+
+    val req = Request[IO](Method.POST, tokenUrl)
+      .withEntity(formData)
+      .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
+
+    httpClient.run(req).use { resp =>
+      resp.status.code match {
+        case code if code >= 200 && code < 300 =>
+          resp.as[Json].flatMap { json =>
+            val cursor = json.hcursor
+            val accessToken = cursor.get[String]("access_token")
+              .getOrElse(throw new RuntimeException("OAuth2 response missing access_token"))
+            val expiresIn = cursor.get[Long]("expires_in").getOrElse(3600L)
+
+            // Expire 60s early to avoid edge cases
+            val expiresAt = Instant.now.plusSeconds(expiresIn - 60)
+            val cached = CachedToken(accessToken, expiresAt)
+
+            tokenRef.set(Some(cached)).as(accessToken)
+          }
+        case code =>
+          resp.as[String].flatMap { body =>
+            IO.raiseError(new RuntimeException(s"OAuth2 token fetch failed ($code): $body"))
+          }
+      }
+    }
+  }
+}
+
+object OAuth2TokenManager {
+
+  final case class CachedToken(accessToken: String, expiresAt: Instant) {
+    def isExpired: Boolean = Instant.now.isAfter(expiresAt)
+  }
+
+  /** Create a token manager resource. The HTTP client is managed internally. */
+  def resource(
+      clientId: String,
+      clientSecret: String,
+      tokenUrl: String,
+      timeout: FiniteDuration = 30.seconds
+  ): Resource[IO, OAuth2TokenManager] = {
+    val uri = Uri.unsafeFromString(tokenUrl)
+
+    for {
+      client <- EmberClientBuilder.default[IO].withTimeout(timeout).build
+      tokenRef <- Resource.eval(Ref.of[IO, Option[CachedToken]](None))
+      lock <- Resource.eval(Semaphore[IO](1))
+    } yield new OAuth2TokenManager(clientId, clientSecret, uri, client, tokenRef, lock)
+  }
+
+  /** Create a token manager with a pre-existing HTTP client. */
+  def apply(
+      clientId: String,
+      clientSecret: String,
+      tokenUrl: String,
+      httpClient: Http4sClient[IO]
+  ): IO[OAuth2TokenManager] = {
+    val uri = Uri.unsafeFromString(tokenUrl)
+    for {
+      tokenRef <- Ref.of[IO, Option[CachedToken]](None)
+      lock <- Semaphore[IO](1)
+    } yield new OAuth2TokenManager(clientId, clientSecret, uri, httpClient, tokenRef, lock)
+  }
+}

--- a/src/test/scala/com/apilytics/core/http/PaginatorSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/PaginatorSuite.scala
@@ -16,7 +16,7 @@ class PaginatorSuite extends CatsEffectSuite {
 
   private def mockClient(responses: List[(Json, Map[String, String])]): Client.RestClient = {
     var callIndex = 0
-    new Client.RestClient(null, dummyHttp, dummyAuth) {
+    new Client.RestClient(null, dummyHttp, dummyAuth, None) {
       override def get(uri: Uri, params: Map[String, String]): IO[ApiResponse] = IO {
         val (json, headers) = responses(callIndex)
         callIndex += 1

--- a/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
@@ -377,4 +377,170 @@ class WireMockSuite extends FunSuite {
     assertEquals(resp.headers.get("X-Request-Id"), Some("abc123"))
     assertEquals(resp.headers.get("X-Rate-Limit-Remaining"), Some("99"))
   }
+
+  // ============== OAUTH2 CLIENT CREDENTIALS TESTS ==============
+
+  test("OAuth2 fetches token and uses it for API requests") {
+    // Token endpoint
+    server.stubFor(
+      post(urlPathEqualTo("/oauth/token"))
+        .withRequestBody(containing("grant_type=client_credentials"))
+        .withRequestBody(containing("client_id=test-client"))
+        .withRequestBody(containing("client_secret=test-secret"))
+        .willReturn(okJson("""{"access_token": "fresh-token", "expires_in": 3600}"""))
+    )
+    // API endpoint requiring auth
+    server.stubFor(
+      get(urlPathEqualTo("/api/data"))
+        .withHeader("Authorization", equalTo("Bearer fresh-token"))
+        .willReturn(okJson("""{"status": "ok"}"""))
+    )
+
+    val authConfig = AuthConfig(
+      authType = AuthType.OAuth2Client,
+      clientId = Some("test-client"),
+      clientSecret = Some("test-secret"),
+      tokenUrl = Some(s"http://localhost:${server.port()}/oauth/token")
+    )
+
+    val resp = Client.resourceWithOAuth2(defaultHttp, authConfig).use { client =>
+      client.get(baseUri.addPath("api/data"))
+    }.unsafeRunSync()
+
+    assertEquals(resp.status, 200)
+    // Verify token was fetched
+    server.verify(1, postRequestedFor(urlPathEqualTo("/oauth/token")))
+  }
+
+  test("OAuth2 refreshes token on 401 and retries") {
+    // Use scenarios to return different tokens on each POST
+    server.stubFor(
+      post(urlPathEqualTo("/oauth/token"))
+        .inScenario("oauth-refresh")
+        .whenScenarioStateIs("Started")
+        .willReturn(okJson("""{"access_token": "first-token", "expires_in": 3600}"""))
+        .willSetStateTo("first-token-issued")
+    )
+    server.stubFor(
+      post(urlPathEqualTo("/oauth/token"))
+        .inScenario("oauth-refresh")
+        .whenScenarioStateIs("first-token-issued")
+        .willReturn(okJson("""{"access_token": "refreshed-token", "expires_in": 3600}"""))
+    )
+    // First API call with first token returns 401
+    server.stubFor(
+      get(urlPathEqualTo("/api/data"))
+        .withHeader("Authorization", equalTo("Bearer first-token"))
+        .willReturn(unauthorized().withBody("Token expired"))
+    )
+    // Retry with refreshed token succeeds
+    server.stubFor(
+      get(urlPathEqualTo("/api/data"))
+        .withHeader("Authorization", equalTo("Bearer refreshed-token"))
+        .willReturn(okJson("""{"status": "ok"}"""))
+    )
+
+    val authConfig = AuthConfig(
+      authType = AuthType.OAuth2Client,
+      clientId = Some("test-client"),
+      clientSecret = Some("test-secret"),
+      tokenUrl = Some(s"http://localhost:${server.port()}/oauth/token")
+    )
+
+    val resp = Client.resourceWithOAuth2(defaultHttp, authConfig).use { client =>
+      client.get(baseUri.addPath("api/data"))
+    }.unsafeRunSync()
+
+    assertEquals(resp.status, 200)
+    // Verify: initial token fetch + refresh
+    server.verify(2, postRequestedFor(urlPathEqualTo("/oauth/token")))
+    // Verify: 2 API calls (first 401, second 200)
+    server.verify(2, getRequestedFor(urlPathEqualTo("/api/data")))
+  }
+
+  test("OAuth2 fails after refresh if still 401") {
+    // Token endpoint always returns same token
+    server.stubFor(
+      post(urlPathEqualTo("/oauth/token"))
+        .willReturn(okJson("""{"access_token": "bad-token", "expires_in": 3600}"""))
+    )
+    // API always returns 401
+    server.stubFor(
+      get(urlPathEqualTo("/api/data"))
+        .willReturn(unauthorized().withBody("Invalid token"))
+    )
+
+    val authConfig = AuthConfig(
+      authType = AuthType.OAuth2Client,
+      clientId = Some("test-client"),
+      clientSecret = Some("test-secret"),
+      tokenUrl = Some(s"http://localhost:${server.port()}/oauth/token")
+    )
+
+    val error = intercept[RuntimeException] {
+      Client.resourceWithOAuth2(defaultHttp, authConfig).use { client =>
+        client.get(baseUri.addPath("api/data"))
+      }.unsafeRunSync()
+    }
+
+    assert(error.getMessage.contains("401"))
+    // Initial fetch + refresh = 2 token fetches
+    server.verify(2, postRequestedFor(urlPathEqualTo("/oauth/token")))
+    // 2 API calls (both 401)
+    server.verify(2, getRequestedFor(urlPathEqualTo("/api/data")))
+  }
+
+  test("OAuth2 token fetch failure throws") {
+    server.stubFor(
+      post(urlPathEqualTo("/oauth/token"))
+        .willReturn(unauthorized().withBody("Invalid credentials"))
+    )
+
+    val authConfig = AuthConfig(
+      authType = AuthType.OAuth2Client,
+      clientId = Some("bad-client"),
+      clientSecret = Some("bad-secret"),
+      tokenUrl = Some(s"http://localhost:${server.port()}/oauth/token")
+    )
+
+    val error = intercept[RuntimeException] {
+      Client.resourceWithOAuth2(defaultHttp, authConfig).use { client =>
+        client.get(baseUri.addPath("api/data"))
+      }.unsafeRunSync()
+    }
+
+    assert(error.getMessage.contains("OAuth2 token fetch failed"))
+  }
+
+  test("OAuth2 caches token across requests") {
+    server.stubFor(
+      post(urlPathEqualTo("/oauth/token"))
+        .willReturn(okJson("""{"access_token": "cached-token", "expires_in": 3600}"""))
+    )
+    server.stubFor(
+      get(urlPathEqualTo("/api/data"))
+        .withHeader("Authorization", equalTo("Bearer cached-token"))
+        .willReturn(okJson("""{"id": 1}"""))
+    )
+
+    val authConfig = AuthConfig(
+      authType = AuthType.OAuth2Client,
+      clientId = Some("test-client"),
+      clientSecret = Some("test-secret"),
+      tokenUrl = Some(s"http://localhost:${server.port()}/oauth/token")
+    )
+
+    Client.resourceWithOAuth2(defaultHttp, authConfig).use { client =>
+      for {
+        _ <- client.get(baseUri.addPath("api/data"))
+        _ <- client.get(baseUri.addPath("api/data"))
+        _ <- client.get(baseUri.addPath("api/data"))
+      } yield ()
+    }.unsafeRunSync()
+
+    // Token should only be fetched once
+    server.verify(1, postRequestedFor(urlPathEqualTo("/oauth/token")))
+    // All 3 API requests should succeed
+    server.verify(3, getRequestedFor(urlPathEqualTo("/api/data")))
+  }
 }


### PR DESCRIPTION
Closes #7

## Summary
- New `OAuth2TokenManager` class for token lifecycle management
- Tokens fetched from `token-url` using `client_id` and `client_secret`
- Tokens cached with expiry tracking (refreshes 60s before expiry)
- Semaphore prevents concurrent refresh race conditions
- `Client.resourceWithOAuth2` factory creates clients with token manager
- 401 responses trigger single token refresh attempt and retry
- `Auth.withTokenManager` for dynamic token application

## Config
```hocon
auth {
  type = oauth2_client
  client-id = ${CLIENT_ID}
  client-secret = ${CLIENT_SECRET}
  token-url = "https://auth.example.com/oauth/token"
}
```

## Test plan
- [x] `sbt test` passes (64 passed, 4 E2E skipped)
- [x] WireMock tests: token fetch, caching, 401 refresh, failure handling
- [ ] Manual test against real OAuth2 provider