### PR TITLE
Add ApiError exception with full request context

### DIFF
--- a/src/main/scala/com/apilytics/core/http/ApiError.scala
+++ b/src/main/scala/com/apilytics/core/http/ApiError.scala
@@ -1,0 +1,122 @@
+package com.apilytics.core.http
+
+import org.http4s.{Method, Uri}
+
+/**
+ * Rich exception for API errors with full request context.
+ *
+ * @param message Human-readable error description
+ * @param endpoint The API endpoint path (e.g., "/api/v2/pokemon")
+ * @param method HTTP method used
+ * @param params Query parameters sent with the request
+ * @param statusCode HTTP status code returned
+ * @param responseBody Response body (may be truncated for large responses)
+ * @param requestId Request ID from response headers, if present
+ * @param retryAttempt Which retry attempt failed (0 = first attempt)
+ * @param cause Underlying exception, if any
+ */
+final case class ApiError(
+    message: String,
+    endpoint: String,
+    method: Method,
+    params: Map[String, String],
+    statusCode: Int,
+    responseBody: String,
+    requestId: Option[String],
+    retryAttempt: Int,
+    cause: Option[Throwable] = None
+) extends RuntimeException(message, cause.orNull) {
+
+  override def getMessage: String = {
+    val paramsStr = if (params.isEmpty) "" else s"?${params.toSeq.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString("&")}"
+    val requestIdStr = requestId.map(id => s"\n  Request-ID: $id").getOrElse("")
+    val retryStr = if (retryAttempt > 0) s" (after $retryAttempt retries)" else ""
+    val bodyPreview = if (responseBody.length > 500) responseBody.take(500) + "..." else responseBody
+
+    s"""API Error: $message$retryStr
+       |  ${method.name} $endpoint$paramsStr
+       |  Status: $statusCode$requestIdStr
+       |  Response: $bodyPreview""".stripMargin
+  }
+}
+
+object ApiError {
+
+  /** Common request ID header names to check. */
+  private val requestIdHeaders = List(
+    "X-Request-Id",
+    "X-Request-ID",
+    "Request-Id",
+    "Request-ID",
+    "X-Correlation-Id",
+    "X-Correlation-ID",
+    "Correlation-Id"
+  )
+
+  /** Extract request ID from response headers. */
+  def extractRequestId(headers: Map[String, String]): Option[String] = {
+    val lowerHeaders = headers.map { case (k, v) => k.toLowerCase -> v }
+    requestIdHeaders.collectFirst {
+      case h if lowerHeaders.contains(h.toLowerCase) => lowerHeaders(h.toLowerCase)
+    }
+  }
+
+  /** Create an auth failure error. */
+  def authFailed(
+      endpoint: String,
+      method: Method,
+      params: Map[String, String],
+      statusCode: Int,
+      responseBody: String,
+      headers: Map[String, String],
+      retryAttempt: Int
+  ): ApiError = ApiError(
+    message = s"Authentication failed",
+    endpoint = endpoint,
+    method = method,
+    params = params,
+    statusCode = statusCode,
+    responseBody = responseBody,
+    requestId = extractRequestId(headers),
+    retryAttempt = retryAttempt
+  )
+
+  /** Create a generic HTTP error. */
+  def httpError(
+      endpoint: String,
+      method: Method,
+      params: Map[String, String],
+      statusCode: Int,
+      responseBody: String,
+      headers: Map[String, String],
+      retryAttempt: Int
+  ): ApiError = {
+    val statusMessage = statusCode match {
+      case 400 => "Bad Request"
+      case 401 => "Unauthorized"
+      case 403 => "Forbidden"
+      case 404 => "Not Found"
+      case 405 => "Method Not Allowed"
+      case 408 => "Request Timeout"
+      case 409 => "Conflict"
+      case 422 => "Unprocessable Entity"
+      case 429 => "Too Many Requests"
+      case 500 => "Internal Server Error"
+      case 502 => "Bad Gateway"
+      case 503 => "Service Unavailable"
+      case 504 => "Gateway Timeout"
+      case _   => "Request Failed"
+    }
+
+    ApiError(
+      message = statusMessage,
+      endpoint = endpoint,
+      method = method,
+      params = params,
+      statusCode = statusCode,
+      responseBody = responseBody,
+      requestId = extractRequestId(headers),
+      retryAttempt = retryAttempt
+    )
+  }
+}

--- a/src/main/scala/com/apilytics/core/http/Client.scala
+++ b/src/main/scala/com/apilytics/core/http/Client.scala
@@ -67,15 +67,18 @@ object Client {
         u.withQueryParam(k, v)
       }
       val baseReq = Request[IO](uri = fullUri)
+      val endpoint = uri.path.renderString
 
       applyAuth(baseReq).flatMap { req =>
-        executeWithRetry(req, baseReq, attempt = 0, authRetried = false)
+        executeWithRetry(req, baseReq, endpoint, params, attempt = 0, authRetried = false)
       }
     }
 
     private def executeWithRetry(
         req: Request[IO],
         baseReq: Request[IO],
+        endpoint: String,
+        params: Map[String, String],
         attempt: Int,
         authRetried: Boolean
     ): IO[ApiResponse] = {
@@ -98,29 +101,47 @@ object Client {
             }
             val delay = retryAfter.getOrElse(exponentialBackoff(attempt))
             // Drain response body before retry
-            resp.body.compile.drain *> IO.sleep(delay) *> executeWithRetry(req, baseReq, attempt + 1, authRetried)
+            resp.body.compile.drain *> IO.sleep(delay) *>
+              executeWithRetry(req, baseReq, endpoint, params, attempt + 1, authRetried)
 
           case code if code >= 500 && attempt < httpConfig.maxRetries =>
             val delay = exponentialBackoff(attempt)
-            resp.body.compile.drain *> IO.sleep(delay) *> executeWithRetry(req, baseReq, attempt + 1, authRetried)
+            resp.body.compile.drain *> IO.sleep(delay) *>
+              executeWithRetry(req, baseReq, endpoint, params, attempt + 1, authRetried)
 
           case 401 if !authRetried && tokenManager.isDefined =>
             // Token may have expired - refresh once and retry
             resp.body.compile.drain *>
               tokenManager.get.refreshToken.flatMap { _ =>
                 applyAuth(baseReq).flatMap { newReq =>
-                  executeWithRetry(newReq, baseReq, attempt, authRetried = true)
+                  executeWithRetry(newReq, baseReq, endpoint, params, attempt, authRetried = true)
                 }
               }
 
           case 401 | 403 =>
             resp.as[String].flatMap { body =>
-              IO.raiseError(new RuntimeException(s"Auth failed (${resp.status.code}): $body"))
+              IO.raiseError(ApiError.authFailed(
+                endpoint = endpoint,
+                method = req.method,
+                params = params,
+                statusCode = resp.status.code,
+                responseBody = body,
+                headers = hdrs,
+                retryAttempt = attempt
+              ))
             }
 
           case code =>
             resp.as[String].flatMap { body =>
-              IO.raiseError(new RuntimeException(s"HTTP $code: $body"))
+              IO.raiseError(ApiError.httpError(
+                endpoint = endpoint,
+                method = req.method,
+                params = params,
+                statusCode = code,
+                responseBody = body,
+                headers = hdrs,
+                retryAttempt = attempt
+              ))
             }
         }
       }

--- a/src/main/scala/com/apilytics/core/http/OAuth2TokenManager.scala
+++ b/src/main/scala/com/apilytics/core/http/OAuth2TokenManager.scala
@@ -57,24 +57,47 @@ class OAuth2TokenManager private (
       .withEntity(formData)
       .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
 
+    val endpoint = tokenUrl.path.renderString
+
     httpClient.run(req).use { resp =>
+      val hdrs = resp.headers.headers.map(h => h.name.toString -> h.value).toMap
+
       resp.status.code match {
         case code if code >= 200 && code < 300 =>
           resp.as[Json].flatMap { json =>
             val cursor = json.hcursor
-            val accessToken = cursor.get[String]("access_token")
-              .getOrElse(throw new RuntimeException("OAuth2 response missing access_token"))
-            val expiresIn = cursor.get[Long]("expires_in").getOrElse(3600L)
+            cursor.get[String]("access_token") match {
+              case Right(accessToken) =>
+                val expiresIn = cursor.get[Long]("expires_in").getOrElse(3600L)
+                // Expire 60s early to avoid edge cases
+                val expiresAt = Instant.now.plusSeconds(expiresIn - 60)
+                val cached = CachedToken(accessToken, expiresAt)
+                tokenRef.set(Some(cached)).as(accessToken)
 
-            // Expire 60s early to avoid edge cases
-            val expiresAt = Instant.now.plusSeconds(expiresIn - 60)
-            val cached = CachedToken(accessToken, expiresAt)
-
-            tokenRef.set(Some(cached)).as(accessToken)
+              case Left(_) =>
+                IO.raiseError(ApiError(
+                  message = "OAuth2 response missing access_token field",
+                  endpoint = endpoint,
+                  method = Method.POST,
+                  params = Map.empty,
+                  statusCode = code,
+                  responseBody = json.noSpaces,
+                  requestId = ApiError.extractRequestId(hdrs),
+                  retryAttempt = 0
+                ))
+            }
           }
         case code =>
           resp.as[String].flatMap { body =>
-            IO.raiseError(new RuntimeException(s"OAuth2 token fetch failed ($code): $body"))
+            IO.raiseError(ApiError.authFailed(
+              endpoint = endpoint,
+              method = Method.POST,
+              params = Map.empty,
+              statusCode = code,
+              responseBody = body,
+              headers = hdrs,
+              retryAttempt = 0
+            ))
           }
       }
     }

--- a/src/test/scala/com/apilytics/core/http/ApiErrorSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/ApiErrorSuite.scala
@@ -1,0 +1,138 @@
+package com.apilytics.core.http
+
+import munit.FunSuite
+import org.http4s.Method
+
+class ApiErrorSuite extends FunSuite {
+
+  test("getMessage formats error with all context") {
+    val error = ApiError(
+      message = "Not Found",
+      endpoint = "/api/v2/pokemon/9999",
+      method = Method.GET,
+      params = Map("limit" -> "10"),
+      statusCode = 404,
+      responseBody = """{"error": "Pokemon not found"}""",
+      requestId = Some("req-123"),
+      retryAttempt = 0
+    )
+
+    val msg = error.getMessage
+    assert(msg.contains("Not Found"))
+    assert(msg.contains("GET /api/v2/pokemon/9999?limit=10"))
+    assert(msg.contains("Status: 404"))
+    assert(msg.contains("Request-ID: req-123"))
+    assert(msg.contains("""{"error": "Pokemon not found"}"""))
+  }
+
+  test("getMessage shows retry count when > 0") {
+    val error = ApiError(
+      message = "Service Unavailable",
+      endpoint = "/api/data",
+      method = Method.GET,
+      params = Map.empty,
+      statusCode = 503,
+      responseBody = "Server overloaded",
+      requestId = None,
+      retryAttempt = 3
+    )
+
+    val msg = error.getMessage
+    assert(msg.contains("after 3 retries"))
+  }
+
+  test("getMessage truncates long response body") {
+    val longBody = "x" * 600
+    val error = ApiError(
+      message = "Bad Request",
+      endpoint = "/api",
+      method = Method.GET,
+      params = Map.empty,
+      statusCode = 400,
+      responseBody = longBody,
+      requestId = None,
+      retryAttempt = 0
+    )
+
+    val msg = error.getMessage
+    assert(msg.contains("..."))
+    assert(msg.length < longBody.length + 200) // significantly truncated
+  }
+
+  test("getMessage omits Request-ID when not present") {
+    val error = ApiError(
+      message = "Error",
+      endpoint = "/api",
+      method = Method.GET,
+      params = Map.empty,
+      statusCode = 500,
+      responseBody = "error",
+      requestId = None,
+      retryAttempt = 0
+    )
+
+    val msg = error.getMessage
+    assert(!msg.contains("Request-ID"))
+  }
+
+  test("getMessage omits params when empty") {
+    val error = ApiError(
+      message = "Error",
+      endpoint = "/api/users",
+      method = Method.GET,
+      params = Map.empty,
+      statusCode = 500,
+      responseBody = "error",
+      requestId = None,
+      retryAttempt = 0
+    )
+
+    val msg = error.getMessage
+    assert(msg.contains("GET /api/users"))
+    assert(!msg.contains("?"))
+  }
+
+  test("extractRequestId finds common header names") {
+    val headers1 = Map("X-Request-Id" -> "id1")
+    assertEquals(ApiError.extractRequestId(headers1), Some("id1"))
+
+    val headers2 = Map("x-correlation-id" -> "id2")
+    assertEquals(ApiError.extractRequestId(headers2), Some("id2"))
+
+    val headers3 = Map("Request-ID" -> "id3")
+    assertEquals(ApiError.extractRequestId(headers3), Some("id3"))
+
+    val headers4 = Map("Content-Type" -> "application/json")
+    assertEquals(ApiError.extractRequestId(headers4), None)
+  }
+
+  test("httpError maps status codes to descriptive messages") {
+    val error404 = ApiError.httpError("/api", Method.GET, Map.empty, 404, "", Map.empty, 0)
+    assertEquals(error404.message, "Not Found")
+
+    val error429 = ApiError.httpError("/api", Method.GET, Map.empty, 429, "", Map.empty, 0)
+    assertEquals(error429.message, "Too Many Requests")
+
+    val error503 = ApiError.httpError("/api", Method.GET, Map.empty, 503, "", Map.empty, 0)
+    assertEquals(error503.message, "Service Unavailable")
+
+    val error418 = ApiError.httpError("/api", Method.GET, Map.empty, 418, "", Map.empty, 0)
+    assertEquals(error418.message, "Request Failed") // unknown status
+  }
+
+  test("authFailed creates error with auth message") {
+    val error = ApiError.authFailed(
+      endpoint = "/api/protected",
+      method = Method.GET,
+      params = Map.empty,
+      statusCode = 401,
+      responseBody = "Unauthorized",
+      headers = Map("X-Request-Id" -> "auth-req-1"),
+      retryAttempt = 0
+    )
+
+    assertEquals(error.message, "Authentication failed")
+    assertEquals(error.statusCode, 401)
+    assertEquals(error.requestId, Some("auth-req-1"))
+  }
+}

--- a/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
@@ -503,13 +503,14 @@ class WireMockSuite extends FunSuite {
       tokenUrl = Some(s"http://localhost:${server.port()}/oauth/token")
     )
 
-    val error = intercept[RuntimeException] {
+    val error = intercept[ApiError] {
       Client.resourceWithOAuth2(defaultHttp, authConfig).use { client =>
         client.get(baseUri.addPath("api/data"))
       }.unsafeRunSync()
     }
 
-    assert(error.getMessage.contains("OAuth2 token fetch failed"))
+    assert(error.statusCode == 401)
+    assert(error.message == "Authentication failed")
   }
 
   test("OAuth2 caches token across requests") {


### PR DESCRIPTION
Closes #51

## Summary
- Introduces `ApiError` case class that captures full request context: endpoint, method, query params, status code, response body, request ID, and retry attempt
- Replaces generic `RuntimeException` throws with structured `ApiError` instances
- Provides descriptive error messages with human-readable status descriptions (Not Found, Service Unavailable, etc.)
- Extracts request IDs from common header formats (X-Request-Id, Correlation-Id, etc.)
- Truncates long response bodies in error output for readability

## Test plan
- [x] Existing tests pass (83 total, 79 passed, 4 skipped e2e)
- [x] New `ApiErrorSuite` tests formatting, truncation, and header extraction
- [x] Updated `WireMockSuite` to assert on `ApiError` properties