### PR TITLE
Add configurable Arrow batch size

### DIFF
--- a/src/main/scala/com/apilytics/core/config/Loader.scala
+++ b/src/main/scala/com/apilytics/core/config/Loader.scala
@@ -79,7 +79,8 @@ object Loader {
         case "explode_view"  => ArrayHandling.ExplodeView
         case "both"          => ArrayHandling.Both
         case other           => throw new IllegalArgumentException(s"Unknown array handling: $other")
-      } else ArrayHandling.KeepArray
+      } else ArrayHandling.KeepArray,
+      arrowBatchSize = if (config.hasPath("arrow-batch-size")) config.getInt("arrow-batch-size") else 4096
     )
   }
 

--- a/src/main/scala/com/apilytics/core/config/Models.scala
+++ b/src/main/scala/com/apilytics/core/config/Models.scala
@@ -48,7 +48,8 @@ final case class PaginationConfig(
 
 final case class SchemaConfig(
     flattenDepth: Int = 2,
-    arrayHandling: ArrayHandling = ArrayHandling.KeepArray
+    arrayHandling: ArrayHandling = ArrayHandling.KeepArray,
+    arrowBatchSize: Int = 4096
 )
 
 final case class HttpConfig(

--- a/src/main/scala/com/apilytics/spark/RESTColumnarPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/RESTColumnarPartitionReader.scala
@@ -45,6 +45,7 @@ class RESTColumnarPartitionReader(partition: RESTInputPartition) extends Partiti
   private def fetchBatches(): Iterator[ColumnarBatch] = {
     val baseUri = Uri.unsafeFromString(partition.baseUrl + partition.endpoint.path)
     val dataPath = partition.tableConfig.flatMap(_.dataPath)
+    val batchSize = partition.sourceConfig.schema.arrowBatchSize
 
     val program: IO[List[ColumnarBatch]] = Client
       .resource(partition.sourceConfig.http, partition.sourceConfig.auth)
@@ -55,9 +56,12 @@ class RESTColumnarPartitionReader(partition: RESTInputPartition) extends Partiti
             val records = Converter.extractRecords(pageJson, dataPath)
             if (records.isEmpty) Stream.empty
             else {
-              val root = Converter.toArrow(records, arrowSchema, allocator)
-              val batch = arrowToBatch(root)
-              Stream.emit(batch)
+              // Chunk records into batches of configured size
+              val chunks = records.grouped(batchSize).toList
+              Stream.emits(chunks.map { chunk =>
+                val root = Converter.toArrow(chunk, arrowSchema, allocator)
+                arrowToBatch(root)
+              })
             }
           }
           .compile

--- a/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
+++ b/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
@@ -116,4 +116,29 @@ class LoaderSuite extends FunSuite {
     assertEquals(Loader.load(withStyle("link_header")).pagination.style, PaginationStyle.LinkHeader)
     assertEquals(Loader.load(withStyle("none")).pagination.style, PaginationStyle.None)
   }
+
+  test("arrow-batch-size defaults to 4096") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    assertEquals(result.schema.arrowBatchSize, 4096)
+  }
+
+  test("arrow-batch-size can be configured") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |schema {
+        |  arrow-batch-size = 1024
+        |}
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    assertEquals(result.schema.arrowBatchSize, 1024)
+  }
 }


### PR DESCRIPTION
Closes #54

## Summary
- Adds `arrow-batch-size` config option to the `schema` section (default: 4096 rows)
- Columnar reader now chunks records from each API page into batches of the configured size
- Allows tuning memory usage vs batch management overhead

## Config
```hocon
schema {
  arrow-batch-size = 4096  # rows per ColumnarBatch
}
```

## Test plan
- [x] New tests verify config parsing and default value
- [x] All 85 tests pass (81 passed, 4 skipped e2e)