### PR TITLE
Add column pruning support (SupportsPushDownRequiredColumns)

### DIFF
--- a/src/main/scala/com/apilytics/spark/ArrowSchemaConverter.scala
+++ b/src/main/scala/com/apilytics/spark/ArrowSchemaConverter.scala
@@ -13,6 +13,17 @@ object ArrowSchemaConverter {
     StructType(fields)
   }
 
+  /** Prune Arrow schema to only include columns in the required Spark schema.
+    * Preserves field metadata (like json.path) from the original Arrow fields.
+    */
+  def pruneSchema(arrowSchema: ArrowSchema, required: StructType): ArrowSchema = {
+    val requiredNames = required.fieldNames.toSet
+    val prunedFields = arrowSchema.getFields.asScala
+      .filter(f => requiredNames.contains(f.getName))
+      .asJava
+    new ArrowSchema(prunedFields)
+  }
+
   private def toSparkField(field: Field): StructField = {
     val sparkType = toSparkType(field.getType)
     StructField(field.getName, sparkType, field.isNullable)

--- a/src/main/scala/com/apilytics/spark/ExplodedArrayScan.scala
+++ b/src/main/scala/com/apilytics/spark/ExplodedArrayScan.scala
@@ -6,10 +6,11 @@ import org.apache.spark.sql.types.StructType
 
 class ExplodedArrayScan(
     table: ExplodedArrayTable,
-    arrowSchema: ArrowSchema
+    arrowSchema: ArrowSchema,
+    prunedSchema: Option[StructType]
 ) extends Scan with Batch {
 
-  override def readSchema(): StructType = table.schema()
+  override def readSchema(): StructType = prunedSchema.getOrElse(table.schema())
 
   override def toBatch(): Batch = this
 

--- a/src/main/scala/com/apilytics/spark/ExplodedArrayScanBuilder.scala
+++ b/src/main/scala/com/apilytics/spark/ExplodedArrayScanBuilder.scala
@@ -1,12 +1,26 @@
 package com.apilytics.spark
 
 import org.apache.arrow.vector.types.pojo.{Schema => ArrowSchema}
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.types.StructType
 
 class ExplodedArrayScanBuilder(
     table: ExplodedArrayTable,
     arrowSchema: ArrowSchema
-) extends ScanBuilder {
+) extends ScanBuilder
+    with SupportsPushDownRequiredColumns {
 
-  override def build(): Scan = new ExplodedArrayScan(table, arrowSchema)
+  private var prunedSchema: Option[StructType] = None
+
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    prunedSchema = Some(requiredSchema)
+  }
+
+  override def build(): Scan = {
+    val finalArrowSchema = prunedSchema match {
+      case Some(required) => ArrowSchemaConverter.pruneSchema(arrowSchema, required)
+      case None           => arrowSchema
+    }
+    new ExplodedArrayScan(table, finalArrowSchema, prunedSchema)
+  }
 }

--- a/src/main/scala/com/apilytics/spark/RESTScan.scala
+++ b/src/main/scala/com/apilytics/spark/RESTScan.scala
@@ -1,15 +1,19 @@
 package com.apilytics.spark
 
+import org.apache.arrow.vector.types.pojo.{Schema => ArrowSchema}
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.types.StructType
 
 class RESTScan(
     table: RESTTable,
+    arrowSchema: ArrowSchema,
+    prunedSchema: Option[StructType],
     pushedParams: Map[String, String],
     pushedLimit: Option[Int]
 ) extends Scan with Batch {
 
-  override def readSchema(): StructType = table.schema()
+  // If pruned, return the pruned schema; otherwise return full schema
+  override def readSchema(): StructType = prunedSchema.getOrElse(table.schema())
 
   override def toBatch(): Batch = this
 
@@ -19,7 +23,7 @@ class RESTScan(
       tableConfig = table.tableConfig,
       sourceConfig = table.sourceConfig,
       baseUrl = table.baseUrl,
-      arrowSchemaJson = table.arrowSchema.toJson,
+      arrowSchemaJson = arrowSchema.toJson,
       pushedParams = pushedParams,
       pushedLimit = pushedLimit
     ))

--- a/src/main/scala/com/apilytics/spark/RESTScanBuilder.scala
+++ b/src/main/scala/com/apilytics/spark/RESTScanBuilder.scala
@@ -3,15 +3,18 @@ package com.apilytics.spark
 import com.apilytics.core.config.FilterConfig
 import org.apache.spark.sql.connector.expressions.{Literal, NamedReference}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownLimit, SupportsPushDownV2Filters}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownLimit, SupportsPushDownRequiredColumns, SupportsPushDownV2Filters}
+import org.apache.spark.sql.types.StructType
 
 class RESTScanBuilder(table: RESTTable) extends ScanBuilder
     with SupportsPushDownV2Filters
-    with SupportsPushDownLimit {
+    with SupportsPushDownLimit
+    with SupportsPushDownRequiredColumns {
 
   private var pushedParams: Map[String, String] = Map.empty
   private var pushedLimit: Option[Int] = None
   private var _pushedPredicates: Array[Predicate] = Array.empty
+  private var prunedSchema: Option[StructType] = None
 
   private val filterConfigs: List[FilterConfig] =
     table.tableConfig.map(_.filters).getOrElse(Nil)
@@ -32,7 +35,17 @@ class RESTScanBuilder(table: RESTTable) extends ScanBuilder
     false
   }
 
-  override def build(): Scan = new RESTScan(table, pushedParams, pushedLimit)
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    prunedSchema = Some(requiredSchema)
+  }
+
+  override def build(): Scan = {
+    val finalArrowSchema = prunedSchema match {
+      case Some(required) => ArrowSchemaConverter.pruneSchema(table.arrowSchema, required)
+      case None           => table.arrowSchema
+    }
+    new RESTScan(table, finalArrowSchema, prunedSchema, pushedParams, pushedLimit)
+  }
 
   private def matchPredicate(predicate: Predicate): Option[(String, String)] = {
     val operator = predicate.name() match {

--- a/src/test/scala/com/apilytics/spark/ColumnPruningSuite.scala
+++ b/src/test/scala/com/apilytics/spark/ColumnPruningSuite.scala
@@ -1,0 +1,95 @@
+package com.apilytics.spark
+
+import munit.FunSuite
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema => ArrowSchema}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+
+import scala.jdk.CollectionConverters._
+
+class ColumnPruningSuite extends FunSuite {
+
+  private def makeArrowSchema(fields: (String, ArrowType)*): ArrowSchema = {
+    val arrowFields = fields.map { case (name, tpe) =>
+      new Field(name, FieldType.nullable(tpe), null)
+    }.toList.asJava
+    new ArrowSchema(arrowFields)
+  }
+
+  test("pruneSchema filters Arrow schema to requested columns") {
+    val fullSchema = makeArrowSchema(
+      "id" -> new ArrowType.Int(32, true),
+      "name" -> ArrowType.Utf8.INSTANCE,
+      "email" -> ArrowType.Utf8.INSTANCE,
+      "age" -> new ArrowType.Int(32, true)
+    )
+
+    val requiredSchema = StructType(Seq(
+      StructField("id", IntegerType),
+      StructField("name", StringType)
+    ))
+
+    val prunedArrowSchema = ArrowSchemaConverter.pruneSchema(fullSchema, requiredSchema)
+
+    assertEquals(prunedArrowSchema.getFields.size(), 2)
+    assertEquals(prunedArrowSchema.getFields.get(0).getName, "id")
+    assertEquals(prunedArrowSchema.getFields.get(1).getName, "name")
+  }
+
+  test("pruneSchema handles single column selection") {
+    val fullSchema = makeArrowSchema(
+      "id" -> new ArrowType.Int(32, true),
+      "name" -> ArrowType.Utf8.INSTANCE,
+      "description" -> ArrowType.Utf8.INSTANCE
+    )
+
+    val requiredSchema = StructType(Seq(
+      StructField("name", StringType)
+    ))
+
+    val prunedArrowSchema = ArrowSchemaConverter.pruneSchema(fullSchema, requiredSchema)
+
+    assertEquals(prunedArrowSchema.getFields.size(), 1)
+    assertEquals(prunedArrowSchema.getFields.get(0).getName, "name")
+  }
+
+  test("pruneSchema preserves field metadata") {
+    // Metadata like json.path is attached to Field objects
+    val metadata = new java.util.HashMap[String, String]()
+    metadata.put("json.path", "address,city")
+
+    val arrowFields = List(
+      new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+      new Field("address_city", new FieldType(true, ArrowType.Utf8.INSTANCE, null, metadata), null)
+    ).asJava
+    val fullSchema = new ArrowSchema(arrowFields)
+
+    val requiredSchema = StructType(Seq(
+      StructField("address_city", StringType)
+    ))
+
+    val prunedArrowSchema = ArrowSchemaConverter.pruneSchema(fullSchema, requiredSchema)
+
+    assertEquals(prunedArrowSchema.getFields.size(), 1)
+    val prunedField = prunedArrowSchema.getFields.get(0)
+    assertEquals(prunedField.getName, "address_city")
+    // Metadata should be preserved from original field
+    assertEquals(prunedField.getMetadata.get("json.path"), "address,city")
+  }
+
+  test("Spark schema is returned from prunedSchema when set") {
+    val fullSparkSchema = StructType(Seq(
+      StructField("id", IntegerType),
+      StructField("name", StringType),
+      StructField("email", StringType)
+    ))
+
+    val prunedSchema = Some(StructType(Seq(
+      StructField("id", IntegerType),
+      StructField("name", StringType)
+    )))
+
+    val readSchema = prunedSchema.getOrElse(fullSparkSchema)
+
+    assertEquals(readSchema.fieldNames.toList, List("id", "name"))
+  }
+}


### PR DESCRIPTION
Closes #46

## Summary
- Implements `SupportsPushDownRequiredColumns` on `RESTScanBuilder` and `ExplodedArrayScanBuilder`
- When Spark calls `pruneColumns()`, only the requested columns are included in the Arrow schema
- Reduces memory usage and Arrow conversion overhead for selective queries like `SELECT id, name FROM api.customers`

## How it works
1. Spark calls `pruneColumns(requiredSchema)` with only the columns needed
2. `RESTScan`/`ExplodedArrayScan` filters the Arrow schema to match
3. The partition reader only allocates and populates vectors for requested columns

## Test plan
- [x] New `ColumnPruningSuite` tests pruning logic
- [x] All 89 tests pass (85 passed, 4 skipped e2e)