### PR TITLE
Fix null value crash in columnar reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,35 @@
 # APIlytics
 
+[![Build](https://github.com/Neutrinic/apilytics/actions/workflows/ci.yml/badge.svg)](https://github.com/Neutrinic/apilytics/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Scala](https://img.shields.io/badge/Scala-2.13-red.svg)](https://www.scala-lang.org/)
+[![Spark](https://img.shields.io/badge/Spark-4.0-orange.svg)](https://spark.apache.org/)
+
 Turn any REST API with an OpenAPI spec into queryable Apache Spark tables.
 
-```sql
-CREATE CATALOG stripe USING apilytics OPTIONS (config '/path/to/stripe.conf')
+## Quick Start
 
-SELECT * FROM stripe.customers WHERE email = 'user@example.com' LIMIT 10
+```bash
+# Build the JAR
+sbt assembly
+
+# Start Spark cluster with GitHub API example
+./scripts/spark-shell.sh github
+```
+
+```scala
+// List available tables
+spark.sql("SHOW TABLES IN api.default").show()
+
+// Query GitHub issues
+spark.sql("SELECT number, title, state FROM api.default.issues LIMIT 10").show()
+
+// Filter and aggregate
+spark.sql("""
+  SELECT state, COUNT(*) as count
+  FROM api.default.issues
+  GROUP BY state
+""").show()
 ```
 
 ## Overview
@@ -14,56 +38,56 @@ APIlytics is a Spark DataSource V2 catalog plugin that reads OpenAPI 3.x specifi
 
 ## Features
 
-- **OpenAPI 3.x** parsing via swagger-parser — GET endpoints with array responses become tables
-- **Pagination** — cursor, offset, and link header strategies with configurable page sizes
-- **Authentication** — bearer token, basic auth, custom headers, OAuth2 client credentials
-- **Filter pushdown** — Spark SQL filters map to API query parameters
-- **Limit pushdown** — stops pagination early when a LIMIT clause is present
-- **Schema flattening** — nested objects flatten to a configurable depth, deeper nesting falls back to VARIANT
-- **Arrow internals** — zero-copy path to Spark ColumnarBatch
+- **OpenAPI 3.x** parsing via swagger-parser - GET endpoints with array responses become tables
+- **Pagination** - cursor, offset, and link header strategies with configurable page sizes
+- **Authentication** - bearer token, basic auth, custom headers, OAuth2 client credentials
+- **Filter pushdown** - Spark SQL filters map to API query parameters
+- **Limit pushdown** - stops pagination early when a LIMIT clause is present
+- **Schema flattening** - nested objects flatten to a configurable depth, deeper nesting falls back to VARIANT
+- **Arrow internals** - zero-copy path to Spark ColumnarBatch
+- **Parent-child joins** - chain API calls (e.g., fetch issues then comments for each)
 
 ## Configuration
 
-APIlytics uses HOCON configuration with native environment variable substitution:
+See [`examples/github/github-config.conf`](examples/github/github-config.conf) for a complete configuration reference with all options documented.
 
 ```hocon
-openapi = "https://api.stripe.com/v1/openapi.json"
+# Minimal example
+openapi = "https://api.example.com/openapi.json"
 
 auth {
-  type = bearer
-  token = ${STRIPE_API_KEY}
+  type = "bearer"
+  token = ${API_TOKEN}
 }
 
 pagination {
-  style = cursor
-  cursor-path = "/meta/next_cursor"  # RFC 6901 JSON Pointer
-  cursor-param = "starting_after"
-  page-size-param = "limit"
+  style = "link_header"       # link_header | cursor | offset | none
+  page-size-param = "per_page"
   max-page-size = 100
 }
 
-schema {
-  flatten-depth = 2
-  array-handling = keep_array  # keep_array | explode_view | both
+http {
+  timeout = "30s"
+  max-retries = 3
+  max-backoff = "30s"
 }
 
-http {
-  max-retries = 5
-  max-backoff = 30s
-  timeout = 30s
+schema {
+  flatten-depth = 2           # 0 = no flattening, nested objects become JSON
+  array-handling = "both"     # keep_array | explode_view | both
 }
 
 tables {
-  customers {
-    endpoint = "/v1/customers"
-    data-path = "/data"
+  issues {
+    endpoint = "/repos/owner/repo/issues"
     filters = [
-      { param = "email", column = "email", operators = ["eq"] }
-      { param = "created[gte]", column = "created_at", operators = ["gte"] }
+      { param = "state", column = "state", operators = ["eq"] }
     ]
   }
 }
 ```
+
+The script registers the catalog as `api`, so queries use `api.default.<table>`.
 
 ## Building
 
@@ -79,8 +103,12 @@ sbt assembly  # fat JAR for Spark
 A Spark standalone cluster is provided for local development:
 
 ```bash
+# Start cluster
 cd docker/spark
 docker compose -f compose.spark.yaml up -d
+
+# Or use the helper script
+./scripts/spark-shell.sh github
 ```
 
 This starts a Spark master, two workers, and a history server. The assembled JAR is mounted automatically.

--- a/docker/spark/compose.spark.yaml
+++ b/docker/spark/compose.spark.yaml
@@ -12,7 +12,7 @@ services:
       - SPARK_ROLE=master
     volumes:
       - spark-events:/opt/spark/spark-events
-      - ../../target/scala-2.13/apilytics-0.1.0-SNAPSHOT.jar:/opt/spark/jars/apilytics.jar:ro
+      - ../../${APILYTICS_JAR:-target/scala-2.13/apilytics.jar}:/opt/spark/jars/apilytics.jar:ro
       - ../../examples:/opt/spark/examples:ro
     ports:
       - "7077:7077"
@@ -33,7 +33,7 @@ services:
       - SPARK_WORKER_MEMORY=4g
     volumes:
       - spark-events:/opt/spark/spark-events
-      - ../../target/scala-2.13/apilytics-0.1.0-SNAPSHOT.jar:/opt/spark/jars/apilytics.jar:ro
+      - ../../${APILYTICS_JAR:-target/scala-2.13/apilytics.jar}:/opt/spark/jars/apilytics.jar:ro
       - ../../examples:/opt/spark/examples:ro
     depends_on:
       - spark-master
@@ -52,7 +52,7 @@ services:
       - SPARK_WORKER_MEMORY=4g
     volumes:
       - spark-events:/opt/spark/spark-events
-      - ../../target/scala-2.13/apilytics-0.1.0-SNAPSHOT.jar:/opt/spark/jars/apilytics.jar:ro
+      - ../../${APILYTICS_JAR:-target/scala-2.13/apilytics.jar}:/opt/spark/jars/apilytics.jar:ro
       - ../../examples:/opt/spark/examples:ro
     depends_on:
       - spark-master

--- a/examples/github/github-config.conf
+++ b/examples/github/github-config.conf
@@ -1,55 +1,145 @@
-# GitHub API configuration
-# Uses the official GitHub OpenAPI spec hosted on GitHub
+# =============================================================================
+# APIlytics Configuration Reference
+# =============================================================================
+# This file serves as both a working GitHub example and documentation for all
+# available configuration options.
 #
 # Usage:
-#   export GITHUB_TOKEN=ghp_xxxxx
-#   spark-shell --jars apilytics.jar \
-#     --conf spark.sql.catalog.github=com.apilytics.spark.RESTCatalog \
-#     --conf spark.sql.catalog.github.config=examples/github/github-config.conf
+#   export GITHUB_TOKEN=ghp_xxxxx  # optional, for higher rate limits
+#   ./scripts/spark-shell.sh github
 #
 # Example queries:
-#   SELECT * FROM github.default.issues LIMIT 10
-#   SELECT title, state, user_login FROM github.default.issues WHERE state = 'open'
+#   spark.sql("SELECT * FROM api.default.issues LIMIT 10").show()
+#   spark.sql("SELECT title, state FROM api.default.issues WHERE state = 'open'").show()
+# =============================================================================
 
+# -----------------------------------------------------------------------------
+# OpenAPI Spec URL (required)
+# -----------------------------------------------------------------------------
+# URL or file path to the OpenAPI 3.x specification (JSON or YAML)
 openapi = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json"
 
-# Auth is optional for public repos (but recommended for higher rate limits)
-# Set GITHUB_TOKEN env var to authenticate
+# -----------------------------------------------------------------------------
+# Authentication
+# -----------------------------------------------------------------------------
+# Supported types: none, bearer, basic, header, oauth2_client
 auth {
   type = "none"
 }
-# Uncomment below if you have a token:
+
+# Bearer token (most common):
 # auth {
 #   type = "bearer"
-#   token = ${?GITHUB_TOKEN}
+#   token = ${GITHUB_TOKEN}       # env var substitution
 # }
 
+# Basic auth:
+# auth {
+#   type = "basic"
+#   username = ${API_USER}
+#   password = ${API_PASS}
+# }
+
+# Custom header:
+# auth {
+#   type = "header"
+#   header-name = "X-API-Key"
+#   header-value = ${API_KEY}
+# }
+
+# OAuth2 client credentials:
+# auth {
+#   type = "oauth2_client"
+#   client-id = ${CLIENT_ID}
+#   client-secret = ${CLIENT_SECRET}
+#   token-url = "https://api.example.com/oauth/token"
+# }
+
+# -----------------------------------------------------------------------------
+# Pagination
+# -----------------------------------------------------------------------------
+# Supported styles: link_header, cursor, offset, none
 pagination {
-  style = "link_header"
-  page-size-param = "per_page"
-  max-page-size = 100
+  style = "link_header"           # GitHub uses RFC 5988 Link headers
+  page-size-param = "per_page"    # query param for page size
+  max-page-size = 100             # maximum items per request
+
+  # For cursor pagination:
+  # cursor-path = "/meta/next_cursor"  # JSON pointer to cursor in response
+  # cursor-param = "cursor"            # query param name for cursor
+
+  # For offset pagination:
+  # offset-param = "offset"       # query param name for offset
+  # results-path = "/results"     # JSON pointer to results array (for empty page detection)
+
+  # Safety limits:
+  # max-pages = 1000              # stop after N pages (prevents infinite loops)
 }
 
+# -----------------------------------------------------------------------------
+# HTTP Client
+# -----------------------------------------------------------------------------
 http {
-  timeout = "30s"
-  max-backoff = "30s"
-  max-retries = 3
+  timeout = "30s"                 # request timeout
+  max-retries = 3                 # retry count for transient failures
+  max-backoff = "30s"             # max delay between retries (exponential backoff)
 }
 
+# -----------------------------------------------------------------------------
+# Schema Options
+# -----------------------------------------------------------------------------
 schema {
-  # GitHub has naming collisions even at depth 1 (repository_url vs repository.url)
-  # Use depth 0 to disable flattening - nested objects become JSON strings
+  # Flattening depth for nested objects:
+  #   0 = no flattening, nested objects become JSON strings
+  #   1 = flatten one level (user.name -> user_name)
+  #   2 = flatten two levels (default)
+  # GitHub has naming collisions at depth 1 (repository_url vs repository.url)
   flatten-depth = 0
+
+  # Array handling:
+  #   keep_array   = arrays stay as arrays (default)
+  #   explode_view = create _exploded view with one row per element
+  #   both         = keep array column AND create exploded view
   array-handling = "both"
+
+  # Arrow batch size (rows per batch, affects memory usage)
+  # arrow-batch-size = 4096
+
+  # Explode semantics for empty arrays:
+  #   false (default) = empty arrays produce no rows (INNER)
+  #   true            = empty arrays produce one row with null (OUTER)
+  # explode-outer = false
 }
 
+# -----------------------------------------------------------------------------
+# Tables
+# -----------------------------------------------------------------------------
+# Define which API endpoints to expose as Spark tables.
+# If omitted, all GET endpoints returning arrays are auto-discovered.
 tables {
-  # List issues for octocat/Hello-World (public repo, no auth needed for read)
-  # GitHub returns arrays directly (no data-path needed)
+  # Simple table: just an endpoint
   issues {
     endpoint = "/repos/octocat/Hello-World/issues"
+
+    # Optional: JSON pointer to data array in response
+    # data-path = "/items"
+
+    # Filter pushdown configuration
+    # Maps SQL WHERE clauses to API query parameters
     filters = [
       { param = "state", column = "state", operators = ["eq"] }
+      { param = "labels", column = "labels", operators = ["eq"] }
+      { param = "since", column = "created_at", operators = ["gte"] }
     ]
+    # Supported operators: eq, neq, gt, gte, lt, lte, like, in
+    # SQL: WHERE state = 'open'  ->  API: ?state=open
   }
+
+  # Parent-child join example (fetch comments for each issue):
+  # issue-comments {
+  #   endpoint = "/repos/octocat/Hello-World/issues/{issue_number}/comments"
+  #   parent-table = "issues"           # parent table name
+  #   parent-key = "number"             # field from parent to substitute
+  #   join-strategy = "nested_loop"     # fetch child for each parent row
+  # }
 }

--- a/scripts/spark-shell.ps1
+++ b/scripts/spark-shell.ps1
@@ -1,13 +1,14 @@
 # Spark shell launcher for Apilytics
-# Usage: .\scripts\spark-shell.ps1 [example-name] [-SkipBuild] [-Force] [-Restart]
+# Usage: .\scripts\spark-shell.ps1 [example-name] [-SkipBuild] [-Force] [-Clean] [-Restart]
 # Example: .\scripts\spark-shell.ps1 pokeapi
 # Example: .\scripts\spark-shell.ps1 github -SkipBuild
-# Example: .\scripts\spark-shell.ps1 github -Force -Restart
+# Example: .\scripts\spark-shell.ps1 github -Force -Clean -Restart
 
 param(
     [string]$Example = "pokeapi",
     [switch]$SkipBuild,
     [switch]$Force,
+    [switch]$Clean,
     [switch]$Restart
 )
 
@@ -17,26 +18,59 @@ if ($Example -notin $ValidExamples) {
     exit 1
 }
 
-$JarFile = "target/scala-2.13/apilytics-0.1.0-SNAPSHOT.jar"
+# Find the JAR file (handles version changes)
+$JarPattern = "target/scala-2.13/apilytics-*.jar"
+$JarFile = Get-ChildItem -Path $JarPattern -ErrorAction SilentlyContinue | Select-Object -First 1
 
 if ($SkipBuild) {
     Write-Host "Skipping build..." -ForegroundColor Yellow
-} elseif (-not $Force -and (Test-Path $JarFile)) {
-    Write-Host "JAR exists, skipping build. Use -Force to rebuild." -ForegroundColor Yellow
+} elseif (-not $Force -and $JarFile) {
+    Write-Host "JAR exists ($($JarFile.Name)), skipping build. Use -Force to rebuild." -ForegroundColor Yellow
 } else {
     Write-Host "Building JAR..." -ForegroundColor Cyan
-    sbt assembly
+    if ($Clean) {
+        sbt clean assembly
+    } else {
+        sbt assembly
+    }
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Build failed"
         exit 1
     }
+    # Re-find JAR after build
+    $JarFile = Get-ChildItem -Path $JarPattern -ErrorAction SilentlyContinue | Select-Object -First 1
+}
+
+# Set env var for docker compose (used in volume mount)
+if ($JarFile) {
+    $env:APILYTICS_JAR = $JarFile.FullName -replace '\\', '/'
+    Write-Host "Using JAR: $($JarFile.Name)" -ForegroundColor Gray
+} else {
+    Write-Error "No JAR found matching $JarPattern"
+    exit 1
 }
 
 # Restart Docker containers if requested (picks up new JAR via volume mount)
 if ($Restart) {
     Write-Host "Restarting Spark containers..." -ForegroundColor Cyan
     docker compose -f docker/spark/compose.spark.yaml restart
-    Start-Sleep -Seconds 3
+
+    # Wait for spark-master to be running
+    $Container = if ($env:SPARK_MASTER_CONTAINER) { $env:SPARK_MASTER_CONTAINER } else { "spark-master" }
+    Write-Host "Waiting for $Container to be ready..." -ForegroundColor Yellow
+    $maxAttempts = 30
+    $attempt = 0
+    do {
+        Start-Sleep -Seconds 1
+        $status = docker inspect -f '{{.State.Running}}' $Container 2>$null
+        $attempt++
+    } while ($status -ne 'true' -and $attempt -lt $maxAttempts)
+
+    if ($status -ne 'true') {
+        Write-Error "Container $Container failed to start"
+        exit 1
+    }
+    Write-Host "$Container is running" -ForegroundColor Green
 }
 
 # Config paths (inside container)

--- a/scripts/spark-shell.sh
+++ b/scripts/spark-shell.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 # Spark shell launcher for Apilytics
-# Usage: ./scripts/spark-shell.sh [example-name] [--skip-build] [--force]
+# Usage: ./scripts/spark-shell.sh [example-name] [--skip-build] [--force] [--clean] [--restart]
 # Example: ./scripts/spark-shell.sh pokeapi
 # Example: ./scripts/spark-shell.sh github --skip-build
+# Example: ./scripts/spark-shell.sh github --force --clean
 
 EXAMPLE="${1:-pokeapi}"
 SKIP_BUILD=false
 RESTART_DOCKER=false
 FORCE=false
+CLEAN=false
 
 # Parse flags
 for arg in "$@"; do
     case $arg in
         --skip-build) SKIP_BUILD=true ;;
         --force) FORCE=true ;;
+        --clean) CLEAN=true ;;
         --restart) RESTART_DOCKER=true ;;
     esac
 done
@@ -24,24 +27,55 @@ if [[ ! " ${VALID_EXAMPLES[*]} " =~ " ${EXAMPLE} " ]]; then
     exit 1
 fi
 
-JAR_FILE="target/scala-2.13/apilytics-0.1.0-SNAPSHOT.jar"
+# Find the JAR file (handles version changes)
+JAR_FILE=$(ls target/scala-2.13/apilytics-*.jar 2>/dev/null | head -1)
 
 if [[ "$SKIP_BUILD" == "true" ]]; then
     echo "Skipping build..."
-elif [[ "$FORCE" != "true" ]] && [[ -f "$JAR_FILE" ]]; then
-    echo "JAR exists, skipping build. Use --force to rebuild."
+elif [[ "$FORCE" != "true" ]] && [[ -n "$JAR_FILE" ]]; then
+    echo "JAR exists ($(basename "$JAR_FILE")), skipping build. Use --force to rebuild."
 else
     echo "Building JAR..."
-    sbt clean assembly || exit 1
+    if [[ "$CLEAN" == "true" ]]; then
+        sbt clean assembly || exit 1
+    else
+        sbt assembly || exit 1
+    fi
+    # Re-find JAR after build
+    JAR_FILE=$(ls target/scala-2.13/apilytics-*.jar 2>/dev/null | head -1)
 fi
+
+# Set env var for docker compose (used in volume mount)
+if [[ -n "$JAR_FILE" ]]; then
+    export APILYTICS_JAR="$JAR_FILE"
+    echo "Using JAR: $(basename "$JAR_FILE")"
+else
+    echo "Error: No JAR found matching target/scala-2.13/apilytics-*.jar"
+    exit 1
+fi
+
+CONTAINER="${SPARK_MASTER_CONTAINER:-spark-master}"
 
 if [[ "$RESTART_DOCKER" == "true" ]]; then
     echo "Restarting cluster..."
     docker compose -f docker/spark/compose.spark.yaml restart || exit 1
-    sleep 3
+
+    # Wait for container to be running
+    echo "Waiting for $CONTAINER to be ready..."
+    for i in {1..30}; do
+        if [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" == "true" ]]; then
+            echo "$CONTAINER is running"
+            break
+        fi
+        sleep 1
+    done
+
+    if [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" != "true" ]]; then
+        echo "Error: $CONTAINER failed to start within 30s"
+        exit 1
+    fi
 fi
 
-CONTAINER="${SPARK_MASTER_CONTAINER:-spark-master}"
 JAR_PATH="/opt/spark/jars/apilytics.jar"
 CONFIG_PATH="/opt/spark/examples/$EXAMPLE/$EXAMPLE-config.conf"
 

--- a/src/main/scala/com/apilytics/spark/LazyColumnarReader.scala
+++ b/src/main/scala/com/apilytics/spark/LazyColumnarReader.scala
@@ -8,7 +8,7 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.types.pojo.{Schema => ArrowSchema}
 import org.apache.spark.sql.connector.read.PartitionReader
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import scala.jdk.CollectionConverters._
 
@@ -101,10 +101,15 @@ abstract class LazyColumnarReader extends PartitionReader[ColumnarBatch] {
     }
   }
 
-  /** Wrap Arrow VectorSchemaRoot as ColumnarBatch with zero-copy ArrowColumnVector wrappers. */
+  /** Wrap Arrow VectorSchemaRoot as ColumnarBatch with null-safe column vector wrappers.
+    *
+    * We use NullSafeArrowColumnVector instead of Spark's ArrowColumnVector because
+    * Arrow's underlying vector.get() throws IllegalStateException on null values.
+    * Our wrapper checks isNull() before accessing values.
+    */
   protected def arrowToBatch(root: VectorSchemaRoot): ColumnarBatch = {
     val vectors = root.getFieldVectors.asScala.map { v =>
-      new ArrowColumnVector(v)
+      NullSafeArrowColumnVector(v)
     }.toArray
     val batch = new ColumnarBatch(vectors.asInstanceOf[Array[org.apache.spark.sql.vectorized.ColumnVector]])
     batch.setNumRows(root.getRowCount)

--- a/src/main/scala/com/apilytics/spark/NullSafeArrowColumnVector.scala
+++ b/src/main/scala/com/apilytics/spark/NullSafeArrowColumnVector.scala
@@ -1,0 +1,128 @@
+package com.apilytics.spark
+
+import org.apache.arrow.vector._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.ColumnVector
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * Null-safe wrapper around Arrow FieldVector for Spark's ColumnVector interface.
+ *
+ * Spark's ArrowColumnVector delegates directly to Arrow's vector.get() methods,
+ * which throw IllegalStateException when accessing null values. This wrapper
+ * checks isNull() before accessing values, returning appropriate defaults for nulls.
+ */
+class NullSafeArrowColumnVector(vector: FieldVector)
+    extends ColumnVector(NullSafeArrowColumnVector.toSparkType(vector)) {
+
+  override def close(): Unit = {
+    // Don't close the vector - it's owned by VectorSchemaRoot and will be closed there
+  }
+
+  override def hasNull: Boolean = vector.getNullCount > 0
+
+  override def numNulls(): Int = vector.getNullCount
+
+  override def isNullAt(rowId: Int): Boolean = vector.isNull(rowId)
+
+  override def getBoolean(rowId: Int): Boolean = {
+    if (vector.isNull(rowId)) false
+    else vector.asInstanceOf[BitVector].get(rowId) == 1
+  }
+
+  override def getByte(rowId: Int): Byte = {
+    if (vector.isNull(rowId)) 0
+    else vector.asInstanceOf[TinyIntVector].get(rowId)
+  }
+
+  override def getShort(rowId: Int): Short = {
+    if (vector.isNull(rowId)) 0
+    else vector.asInstanceOf[SmallIntVector].get(rowId)
+  }
+
+  override def getInt(rowId: Int): Int = {
+    if (vector.isNull(rowId)) 0
+    else vector match {
+      case v: IntVector => v.get(rowId)
+      case v: DateDayVector => v.get(rowId)
+      case _ => 0
+    }
+  }
+
+  override def getLong(rowId: Int): Long = {
+    if (vector.isNull(rowId)) 0L
+    else vector match {
+      case v: BigIntVector => v.get(rowId)
+      case v: TimeStampVector => v.get(rowId)
+      case _ => 0L
+    }
+  }
+
+  override def getFloat(rowId: Int): Float = {
+    if (vector.isNull(rowId)) 0f
+    else vector.asInstanceOf[Float4Vector].get(rowId)
+  }
+
+  override def getDouble(rowId: Int): Double = {
+    if (vector.isNull(rowId)) 0d
+    else vector.asInstanceOf[Float8Vector].get(rowId)
+  }
+
+  override def getDecimal(rowId: Int, precision: Int, scale: Int): org.apache.spark.sql.types.Decimal = {
+    if (vector.isNull(rowId)) Decimal(0)
+    else {
+      val v = vector.asInstanceOf[DecimalVector]
+      val bd = v.getObject(rowId)
+      Decimal.apply(bd, precision, scale)
+    }
+  }
+
+  // Note: We return EMPTY_UTF8/empty array for nulls instead of null because Spark's
+  // codegen (UnsafeWriter) can call getters without checking isNullAt() first, causing NPE.
+  // Spark still correctly identifies nulls via isNullAt() which we implement properly.
+  override def getUTF8String(rowId: Int): UTF8String = {
+    if (vector.isNull(rowId)) UTF8String.EMPTY_UTF8
+    else {
+      val v = vector.asInstanceOf[VarCharVector]
+      val bytes = v.get(rowId)
+      UTF8String.fromBytes(bytes)
+    }
+  }
+
+  override def getBinary(rowId: Int): Array[Byte] = {
+    if (vector.isNull(rowId)) Array.emptyByteArray
+    else vector.asInstanceOf[VarBinaryVector].get(rowId)
+  }
+
+  override def getArray(rowId: Int): org.apache.spark.sql.vectorized.ColumnarArray = {
+    throw new UnsupportedOperationException("Array type not supported")
+  }
+
+  override def getMap(rowId: Int): org.apache.spark.sql.vectorized.ColumnarMap = {
+    throw new UnsupportedOperationException("Map type not supported")
+  }
+
+  override def getChild(ordinal: Int): ColumnVector = {
+    throw new UnsupportedOperationException("Struct type not supported")
+  }
+}
+
+object NullSafeArrowColumnVector {
+  def apply(vector: FieldVector): NullSafeArrowColumnVector = new NullSafeArrowColumnVector(vector)
+
+  private[spark] def toSparkType(vector: FieldVector): DataType = vector match {
+    case _: BitVector => BooleanType
+    case _: TinyIntVector => ByteType
+    case _: SmallIntVector => ShortType
+    case _: IntVector => IntegerType
+    case _: BigIntVector => LongType
+    case _: Float4Vector => FloatType
+    case _: Float8Vector => DoubleType
+    case _: VarCharVector => StringType
+    case _: VarBinaryVector => BinaryType
+    case _: DateDayVector => DateType
+    case _: TimeStampVector => TimestampType
+    case _: DecimalVector => DecimalType.SYSTEM_DEFAULT
+    case _ => StringType
+  }
+}


### PR DESCRIPTION
Closes #73

## Summary
- Add `NullSafeArrowColumnVector` wrapper that checks `isNull()` before accessing Arrow vector values
- Return safe defaults for null values since Spark's codegen can call getters without checking `isNullAt()` first
- Use dynamic JAR path in docker compose via `APILYTICS_JAR` env var

## Test plan
- [x] `SELECT * FROM api.default.issues LIMIT 5` no longer crashes on null timestamps/strings
- [x] `SELECT number, title, state, body, closed_at FROM api.default.issues LIMIT 10` works
- [x] `SELECT COUNT(*) as total, COUNT(closed_at) as with_closed_date FROM api.default.issues` works