### PR TITLE
Add Stripe example configuration

### DIFF
--- a/examples/stripe/stripe-config.conf
+++ b/examples/stripe/stripe-config.conf
@@ -1,0 +1,140 @@
+# =============================================================================
+# Stripe API Configuration
+# =============================================================================
+# Demonstrates cursor pagination with data-path extraction.
+# Stripe wraps responses in { "object": "list", "data": [...], "has_more": true }
+#
+# Usage:
+#   export STRIPE_API_KEY=sk_test_xxxxx
+#   ./scripts/spark-shell.sh stripe
+#
+# Example queries:
+#   spark.sql("SELECT id, email, name FROM api.default.customers LIMIT 10").show()
+#   spark.sql("SELECT id, amount, status FROM api.default.charges WHERE status = 'succeeded'").show()
+# =============================================================================
+
+# Stripe's OpenAPI spec (large ~2MB file)
+openapi = "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
+
+# Stripe REQUIRES authentication - set STRIPE_API_KEY env var
+# Get a test key from https://dashboard.stripe.com/test/apikeys
+auth {
+  type = "bearer"
+  token = ${?STRIPE_API_KEY}  # Optional substitution - won't fail if unset, but API will 401
+}
+
+# Stripe uses cursor pagination with `starting_after` parameter
+# Response format: { "data": [...], "has_more": true/false }
+pagination {
+  style = "cursor"
+  cursor-param = "starting_after"    # query param for cursor
+  cursor-path = "/data/-1/id"        # JSON pointer to last item's ID (cursor value)
+  page-size-param = "limit"
+  max-page-size = 100
+
+  # Safety limit - Stripe has no "total count" so we cap pages
+  max-pages = 100
+}
+
+http {
+  timeout = "30s"
+  max-retries = 3
+  max-backoff = "30s"
+
+  # Stripe rate limits:
+  #   - Live mode: 100 req/s
+  #   - Test mode: 25 req/s
+  # TODO: Add rate-limit config once #77 is implemented
+  # rate-limit = 25
+}
+
+schema {
+  # Stripe objects are deeply nested (customer.address.city, etc.)
+  # Flatten 2 levels for usability
+  flatten-depth = 2
+  array-handling = "both"
+}
+
+tables {
+  # Core resources
+  customers {
+    endpoint = "/v1/customers"
+    data-path = "/data"              # Extract array from response wrapper
+    filters = [
+      { param = "email", column = "email", operators = ["eq"] }
+      { param = "created[gte]", column = "created", operators = ["gte"] }
+      { param = "created[lte]", column = "created", operators = ["lte"] }
+    ]
+  }
+
+  charges {
+    endpoint = "/v1/charges"
+    data-path = "/data"
+    filters = [
+      { param = "customer", column = "customer", operators = ["eq"] }
+      { param = "created[gte]", column = "created", operators = ["gte"] }
+      { param = "created[lte]", column = "created", operators = ["lte"] }
+    ]
+  }
+
+  invoices {
+    endpoint = "/v1/invoices"
+    data-path = "/data"
+    filters = [
+      { param = "customer", column = "customer", operators = ["eq"] }
+      { param = "status", column = "status", operators = ["eq"] }
+      { param = "created[gte]", column = "created", operators = ["gte"] }
+    ]
+  }
+
+  subscriptions {
+    endpoint = "/v1/subscriptions"
+    data-path = "/data"
+    filters = [
+      { param = "customer", column = "customer", operators = ["eq"] }
+      { param = "status", column = "status", operators = ["eq"] }
+      { param = "price", column = "price", operators = ["eq"] }
+    ]
+  }
+
+  products {
+    endpoint = "/v1/products"
+    data-path = "/data"
+    filters = [
+      { param = "active", column = "active", operators = ["eq"] }
+      { param = "type", column = "type", operators = ["eq"] }
+    ]
+  }
+
+  prices {
+    endpoint = "/v1/prices"
+    data-path = "/data"
+    filters = [
+      { param = "product", column = "product", operators = ["eq"] }
+      { param = "active", column = "active", operators = ["eq"] }
+      { param = "type", column = "type", operators = ["eq"] }
+    ]
+  }
+
+  # Payment methods and intents
+  payment_intents {
+    endpoint = "/v1/payment_intents"
+    data-path = "/data"
+    filters = [
+      { param = "customer", column = "customer", operators = ["eq"] }
+      { param = "created[gte]", column = "created", operators = ["gte"] }
+    ]
+  }
+
+  # Example parent-child join: charges for each customer
+  # customer-charges {
+  #   endpoint = "/v1/charges"
+  #   data-path = "/data"
+  #   parent-table = "customers"
+  #   parent-key = "id"
+  #   # Note: Uses filter param, not path param for Stripe
+  #   filters = [
+  #     { param = "customer", column = "_parent_id", operators = ["eq"] }
+  #   ]
+  # }
+}

--- a/scripts/spark-shell.ps1
+++ b/scripts/spark-shell.ps1
@@ -12,7 +12,7 @@ param(
     [switch]$Restart
 )
 
-$ValidExamples = @("pokeapi", "github")
+$ValidExamples = @("pokeapi", "github", "stripe")
 if ($Example -notin $ValidExamples) {
     Write-Error "Unknown example: $Example. Available: $($ValidExamples -join ', ')"
     exit 1
@@ -42,8 +42,9 @@ if ($SkipBuild) {
 }
 
 # Set env var for docker compose (used in volume mount)
+# Must be relative path from repo root (compose prepends ../../)
 if ($JarFile) {
-    $env:APILYTICS_JAR = $JarFile.FullName -replace '\\', '/'
+    $env:APILYTICS_JAR = "target/scala-2.13/$($JarFile.Name)"
     Write-Host "Using JAR: $($JarFile.Name)" -ForegroundColor Gray
 } else {
     Write-Error "No JAR found matching $JarPattern"
@@ -91,10 +92,18 @@ if ($Example -eq "pokeapi") {
 } elseif ($Example -eq "github") {
     Write-Host '  spark.sql("SELECT number, title, state FROM api.default.issues LIMIT 10").show()' -ForegroundColor DarkGray
     Write-Host '  spark.sql("SELECT number, title FROM api.default.issues WHERE state = ''open''").show()' -ForegroundColor DarkGray
+} elseif ($Example -eq "stripe") {
+    Write-Host '  spark.sql("SELECT id, email, name FROM api.default.customers LIMIT 10").show()' -ForegroundColor DarkGray
+    Write-Host '  spark.sql("SELECT id, amount, status FROM api.default.charges LIMIT 10").show()' -ForegroundColor DarkGray
 }
 Write-Host ""
 
-docker exec -it $Container spark-shell `
+# Build env var args to pass to container
+$EnvArgs = @()
+if ($env:GITHUB_TOKEN) { $EnvArgs += @("-e", "GITHUB_TOKEN=$env:GITHUB_TOKEN") }
+if ($env:STRIPE_API_KEY) { $EnvArgs += @("-e", "STRIPE_API_KEY=$env:STRIPE_API_KEY") }
+
+docker exec -it @EnvArgs $Container spark-shell `
     --jars $JarPath `
     --conf "spark.sql.catalog.api=com.apilytics.spark.RESTCatalog" `
     --conf "spark.sql.catalog.api.config=$ConfigPath"

--- a/scripts/spark-shell.sh
+++ b/scripts/spark-shell.sh
@@ -21,7 +21,7 @@ for arg in "$@"; do
     esac
 done
 
-VALID_EXAMPLES=("pokeapi" "github")
+VALID_EXAMPLES=("pokeapi" "github" "stripe")
 if [[ ! " ${VALID_EXAMPLES[*]} " =~ " ${EXAMPLE} " ]]; then
     echo "Unknown example: $EXAMPLE. Available: ${VALID_EXAMPLES[*]}"
     exit 1
@@ -92,10 +92,18 @@ if [[ "$EXAMPLE" == "pokeapi" ]]; then
 elif [[ "$EXAMPLE" == "github" ]]; then
     echo '  spark.sql("SELECT number, title, state FROM api.default.issues LIMIT 10").show()'
     echo '  spark.sql("SELECT number, title FROM api.default.issues WHERE state = '\''open'\''").show()'
+elif [[ "$EXAMPLE" == "stripe" ]]; then
+    echo '  spark.sql("SELECT id, email, name FROM api.default.customers LIMIT 10").show()'
+    echo '  spark.sql("SELECT id, amount, status FROM api.default.charges LIMIT 10").show()'
 fi
 echo ""
 
-docker exec -it "$CONTAINER" spark-shell \
+# Build env var args to pass to container
+ENV_ARGS=""
+[[ -n "$GITHUB_TOKEN" ]] && ENV_ARGS="$ENV_ARGS -e GITHUB_TOKEN=$GITHUB_TOKEN"
+[[ -n "$STRIPE_API_KEY" ]] && ENV_ARGS="$ENV_ARGS -e STRIPE_API_KEY=$STRIPE_API_KEY"
+
+docker exec -it $ENV_ARGS "$CONTAINER" spark-shell \
     --jars "$JAR_PATH" \
     --conf "spark.sql.catalog.api=com.apilytics.spark.RESTCatalog" \
     --conf "spark.sql.catalog.api.config=$CONFIG_PATH"


### PR DESCRIPTION
Closes #86

## Summary
- Add Stripe example demonstrating cursor pagination with `data-path` extraction
- Configure 7 tables: customers, charges, invoices, subscriptions, products, prices, payment_intents
- Show filter pushdown for timestamp ranges (`created[gte]`, `created[lte]`)

## Test plan
- [x] `./scripts/spark-shell.sh stripe` launches with correct config
- [x] Example queries display in shell startup