### PR TITLE
Add Slack example with cursor pagination

### DIFF
--- a/examples/slack/slack-config.conf
+++ b/examples/slack/slack-config.conf
@@ -1,0 +1,74 @@
+# =============================================================================
+# Slack API Configuration
+# =============================================================================
+# Demonstrates cursor-based pagination with response_metadata.next_cursor.
+# Slack wraps list responses with cursor info for pagination.
+#
+# REQUIREMENTS:
+#   - A Slack workspace
+#   - A Slack app with bot token (xoxb-...) with channels:read, users:read scopes
+#   - See: https://api.slack.com/apps
+#
+# Usage:
+#   export SLACK_BOT_TOKEN=xoxb-xxxxx
+#   ./scripts/spark-shell.sh slack
+#
+# Example queries:
+#   spark.sql("SELECT id, name FROM api.default.channels LIMIT 10").show()
+#   spark.sql("SELECT id, name, real_name FROM api.default.users LIMIT 10").show()
+#
+# NOTE: Slack returns HTTP 200 with {"ok": false, "error": "..."} on API errors.
+# The connector checks HTTP status codes, so Slack-level errors may appear as
+# empty results rather than exceptions. Check the Slack app's scopes if queries
+# return no data.
+# =============================================================================
+
+# Local OpenAPI 3 spec (Slack's official spec is Swagger 2.0, which we don't support)
+# This minimal spec defines the channels and users endpoints
+openapi = "/opt/spark/examples/slack/slack-openapi.json"
+
+# Bearer token auth using bot token
+auth {
+  type = "bearer"
+  token = ${SLACK_BOT_TOKEN}
+}
+
+# Slack uses cursor pagination
+# Request: ?limit=N&cursor=<cursor>
+# Response: { "channels": [...], "response_metadata": { "next_cursor": "..." } }
+pagination {
+  style = "cursor"
+  cursor-param = "cursor"
+  cursor-path = "/response_metadata/next_cursor"
+  page-size-param = "limit"
+  max-page-size = 200
+  max-pages = 100
+}
+
+http {
+  timeout = "30s"
+  max-retries = 3
+  max-backoff = "30s"
+}
+
+schema {
+  flatten-depth = 2
+  array-handling = "both"
+}
+
+tables {
+  # List all public channels in the workspace
+  channels {
+    endpoint = "/conversations.list"
+    data-path = "/channels"
+    filters = [
+      { param = "types", column = "types", operators = ["eq"] }
+    ]
+  }
+
+  # List all users in the workspace
+  users {
+    endpoint = "/users.list"
+    data-path = "/members"
+  }
+}

--- a/examples/slack/slack-openapi.json
+++ b/examples/slack/slack-openapi.json
@@ -1,0 +1,190 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Slack Web API",
+    "version": "1.0.0",
+    "description": "Minimal OpenAPI 3 spec for Slack Web API (channels and users endpoints)"
+  },
+  "servers": [
+    {
+      "url": "https://slack.com/api"
+    }
+  ],
+  "paths": {
+    "/conversations.list": {
+      "get": {
+        "operationId": "conversations_list",
+        "summary": "List all channels in a Slack workspace",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "channels": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Channel"
+                      }
+                    },
+                    "response_metadata": {
+                      "type": "object",
+                      "properties": {
+                        "next_cursor": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users.list": {
+      "get": {
+        "operationId": "users_list",
+        "summary": "List all users in a Slack workspace",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "members": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/User"
+                      }
+                    },
+                    "response_metadata": {
+                      "type": "object",
+                      "properties": {
+                        "next_cursor": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Channel": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "name_normalized": { "type": "string" },
+          "is_channel": { "type": "boolean" },
+          "is_group": { "type": "boolean" },
+          "is_im": { "type": "boolean" },
+          "is_mpim": { "type": "boolean" },
+          "is_private": { "type": "boolean" },
+          "is_archived": { "type": "boolean" },
+          "is_general": { "type": "boolean" },
+          "is_shared": { "type": "boolean" },
+          "is_org_shared": { "type": "boolean" },
+          "is_member": { "type": "boolean" },
+          "created": { "type": "integer" },
+          "creator": { "type": "string" },
+          "num_members": { "type": "integer" },
+          "topic": {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" },
+              "creator": { "type": "string" },
+              "last_set": { "type": "integer" }
+            }
+          },
+          "purpose": {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" },
+              "creator": { "type": "string" },
+              "last_set": { "type": "integer" }
+            }
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "team_id": { "type": "string" },
+          "name": { "type": "string" },
+          "deleted": { "type": "boolean" },
+          "real_name": { "type": "string" },
+          "tz": { "type": "string" },
+          "tz_label": { "type": "string" },
+          "tz_offset": { "type": "integer" },
+          "is_admin": { "type": "boolean" },
+          "is_owner": { "type": "boolean" },
+          "is_primary_owner": { "type": "boolean" },
+          "is_restricted": { "type": "boolean" },
+          "is_ultra_restricted": { "type": "boolean" },
+          "is_bot": { "type": "boolean" },
+          "is_app_user": { "type": "boolean" },
+          "updated": { "type": "integer" },
+          "profile": {
+            "type": "object",
+            "properties": {
+              "title": { "type": "string" },
+              "phone": { "type": "string" },
+              "real_name": { "type": "string" },
+              "real_name_normalized": { "type": "string" },
+              "display_name": { "type": "string" },
+              "display_name_normalized": { "type": "string" },
+              "email": { "type": "string" },
+              "image_24": { "type": "string" },
+              "image_32": { "type": "string" },
+              "image_48": { "type": "string" },
+              "image_72": { "type": "string" },
+              "image_192": { "type": "string" },
+              "image_512": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/spark-shell.ps1
+++ b/scripts/spark-shell.ps1
@@ -12,9 +12,17 @@ param(
     [switch]$Restart
 )
 
-$ValidExamples = @("pokeapi", "github")
+$ValidExamples = @("pokeapi", "github", "slack")
 if ($Example -notin $ValidExamples) {
     Write-Error "Unknown example: $Example. Available: $($ValidExamples -join ', ')"
+    exit 1
+}
+
+# Check required env vars early (before build)
+if ($Example -eq "slack" -and -not $env:SLACK_BOT_TOKEN) {
+    Write-Error "SLACK_BOT_TOKEN environment variable is required for Slack example"
+    Write-Host "Create a Slack app at https://api.slack.com/apps" -ForegroundColor Yellow
+    Write-Host 'Set it with: $env:SLACK_BOT_TOKEN = "xoxb-..."' -ForegroundColor Yellow
     exit 1
 }
 
@@ -91,10 +99,18 @@ if ($Example -eq "pokeapi") {
 } elseif ($Example -eq "github") {
     Write-Host '  spark.sql("SELECT number, title, state FROM api.default.issues LIMIT 10").show()' -ForegroundColor DarkGray
     Write-Host '  spark.sql("SELECT number, title FROM api.default.issues WHERE state = ''open''").show()' -ForegroundColor DarkGray
+} elseif ($Example -eq "slack") {
+    Write-Host '  spark.sql("SELECT id, name FROM api.default.channels LIMIT 10").show()' -ForegroundColor DarkGray
+    Write-Host '  spark.sql("SELECT id, name, real_name FROM api.default.users LIMIT 10").show()' -ForegroundColor DarkGray
 }
 Write-Host ""
 
-docker exec -it $Container spark-shell `
+# Build env var args to pass to container
+$EnvArgs = @()
+if ($env:GITHUB_TOKEN) { $EnvArgs += @("-e", "GITHUB_TOKEN=$env:GITHUB_TOKEN") }
+if ($env:SLACK_BOT_TOKEN) { $EnvArgs += @("-e", "SLACK_BOT_TOKEN=$env:SLACK_BOT_TOKEN") }
+
+docker exec -it @EnvArgs $Container spark-shell `
     --jars $JarPath `
     --conf "spark.sql.catalog.api=com.apilytics.spark.RESTCatalog" `
     --conf "spark.sql.catalog.api.config=$ConfigPath"

--- a/scripts/spark-shell.sh
+++ b/scripts/spark-shell.sh
@@ -21,9 +21,17 @@ for arg in "$@"; do
     esac
 done
 
-VALID_EXAMPLES=("pokeapi" "github")
+VALID_EXAMPLES=("pokeapi" "github" "slack")
 if [[ ! " ${VALID_EXAMPLES[*]} " =~ " ${EXAMPLE} " ]]; then
     echo "Unknown example: $EXAMPLE. Available: ${VALID_EXAMPLES[*]}"
+    exit 1
+fi
+
+# Check required env vars early (before build)
+if [[ "$EXAMPLE" == "slack" ]] && [[ -z "$SLACK_BOT_TOKEN" ]]; then
+    echo "Error: SLACK_BOT_TOKEN environment variable is required for Slack example"
+    echo "Create a Slack app at https://api.slack.com/apps"
+    echo 'Set it with: export SLACK_BOT_TOKEN="xoxb-..."'
     exit 1
 fi
 
@@ -92,10 +100,18 @@ if [[ "$EXAMPLE" == "pokeapi" ]]; then
 elif [[ "$EXAMPLE" == "github" ]]; then
     echo '  spark.sql("SELECT number, title, state FROM api.default.issues LIMIT 10").show()'
     echo '  spark.sql("SELECT number, title FROM api.default.issues WHERE state = '\''open'\''").show()'
+elif [[ "$EXAMPLE" == "slack" ]]; then
+    echo '  spark.sql("SELECT id, name FROM api.default.channels LIMIT 10").show()'
+    echo '  spark.sql("SELECT id, name, real_name FROM api.default.users LIMIT 10").show()'
 fi
 echo ""
 
-docker exec -it "$CONTAINER" spark-shell \
+# Build env var args to pass to container (use array for proper quoting)
+ENV_ARGS=()
+[[ -n "$GITHUB_TOKEN" ]] && ENV_ARGS+=(-e "GITHUB_TOKEN=$GITHUB_TOKEN")
+[[ -n "$SLACK_BOT_TOKEN" ]] && ENV_ARGS+=(-e "SLACK_BOT_TOKEN=$SLACK_BOT_TOKEN")
+
+docker exec -it "${ENV_ARGS[@]}" "$CONTAINER" spark-shell \
     --jars "$JAR_PATH" \
     --conf "spark.sql.catalog.api=com.apilytics.spark.RESTCatalog" \
     --conf "spark.sql.catalog.api.config=$CONFIG_PATH"

--- a/src/main/scala/com/apilytics/core/config/Loader.scala
+++ b/src/main/scala/com/apilytics/core/config/Loader.scala
@@ -27,7 +27,8 @@ object Loader {
       http = if (config.hasPath("http")) readHttp(config.getConfig("http"))
              else HttpConfig(maxBackoff = 30.seconds, timeout = 30.seconds),
       tables = if (config.hasPath("tables")) readTables(config.getConfig("tables"))
-               else Map.empty
+               else Map.empty,
+      baseUrl = optional(config, "base-url")
     )
   }
 

--- a/src/main/scala/com/apilytics/core/config/Models.scala
+++ b/src/main/scala/com/apilytics/core/config/Models.scala
@@ -99,5 +99,8 @@ final case class SourceConfig(
     pagination: PaginationConfig = PaginationConfig(),
     schema: SchemaConfig = SchemaConfig(),
     http: HttpConfig,
-    tables: Map[String, TableConfig] = Map.empty
+    tables: Map[String, TableConfig] = Map.empty,
+    /** Override the base URL from the OpenAPI spec. Useful when the spec doesn't
+      * include servers or when you want to point to a different environment. */
+    baseUrl: Option[String] = None
 )

--- a/src/main/scala/com/apilytics/spark/RESTCatalog.scala
+++ b/src/main/scala/com/apilytics/spark/RESTCatalog.scala
@@ -22,6 +22,9 @@ class RESTCatalog extends CatalogPlugin with TableCatalog with SupportsNamespace
   private var config: SourceConfig = _
   private var spec: ParsedSpec = _
 
+  /** Returns the effective base URL, preferring config override over OpenAPI spec. */
+  private def effectiveBaseUrl: String = config.baseUrl.getOrElse(spec.baseUrl)
+
   override def name(): String = catalogName
 
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
@@ -96,7 +99,7 @@ class RESTCatalog extends CatalogPlugin with TableCatalog with SupportsNamespace
       endpoint = endpoint,
       tableConfig = tableConfig,
       sourceConfig = config,
-      baseUrl = spec.baseUrl
+      baseUrl = effectiveBaseUrl
     )
   }
 
@@ -167,7 +170,7 @@ class RESTCatalog extends CatalogPlugin with TableCatalog with SupportsNamespace
       childResponseSchema = childEndpoint.responseSchema,
       tableConfig = tableConfig,
       sourceConfig = config,
-      baseUrl = spec.baseUrl
+      baseUrl = effectiveBaseUrl
     )
   }
 
@@ -189,7 +192,7 @@ class RESTCatalog extends CatalogPlugin with TableCatalog with SupportsNamespace
       endpoint = endpoint,
       tableConfig = tableConfig,
       sourceConfig = config,
-      baseUrl = spec.baseUrl
+      baseUrl = effectiveBaseUrl
     )
   }
 


### PR DESCRIPTION
Closes #88

## Summary
- Add Slack example demonstrating cursor-based pagination
- Add `base-url` config override for SourceConfig
- Update scripts to support slack example with `SLACK_BOT_TOKEN` env var

## Changes
- `examples/slack/slack-config.conf` - Slack configuration
- `examples/slack/slack-openapi.json` - Minimal OpenAPI 3 spec (Slack's official is Swagger 2.0)
- `src/main/scala/com/apilytics/core/config/Models.scala` - Add `baseUrl` to SourceConfig
- `src/main/scala/com/apilytics/core/config/Loader.scala` - Parse `base-url` config
- `src/main/scala/com/apilytics/spark/RESTCatalog.scala` - Use config baseUrl override
- `scripts/spark-shell.{ps1,sh}` - Add slack example support

## Test plan
- [x] `spark.sql("SELECT id, name FROM api.default.channels LIMIT 10").show()` returns channels
- [x] `spark.sql("SELECT id, name, real_name FROM api.default.users LIMIT 10").show()` returns users