### PR TITLE
Add retry on transient network errors

### DIFF
--- a/src/main/scala/com/apilytics/core/http/Client.scala
+++ b/src/main/scala/com/apilytics/core/http/Client.scala
@@ -157,6 +157,31 @@ object Client {
               ))
             }
         }
+      }.handleErrorWith {
+        // Retry on network-level transient failures (connection timeout, socket errors, etc.)
+        case e if isTransientNetworkError(e) && attempt < httpConfig.maxRetries =>
+          val delay = exponentialBackoff(attempt)
+          IO.sleep(delay) *>
+            executeWithRetry(req, baseReq, endpoint, params, attempt + 1, authRetried)
+        case e => IO.raiseError(e)
+      }
+    }
+
+    /** Check if an exception is a transient network error worth retrying. */
+    private def isTransientNetworkError(e: Throwable): Boolean = {
+      import java.net.{ConnectException, SocketException, SocketTimeoutException}
+      import java.io.IOException
+      import java.util.concurrent.TimeoutException
+
+      e match {
+        case _: ConnectException       => true  // Connection refused, host unreachable
+        case _: SocketException        => true  // Connection reset, broken pipe
+        case _: SocketTimeoutException => true  // Read/connect timeout at socket level
+        case _: TimeoutException       => true  // General timeout (e.g., from http4s)
+        case e: IOException if e.getMessage != null &&
+          (e.getMessage.contains("Connection reset") ||
+           e.getMessage.contains("Broken pipe")) => true
+        case _ => false
       }
     }
 


### PR DESCRIPTION
Closes #78

## Summary
Extends page-level retry to handle network-level transient failures in addition to HTTP 429/5xx.

## Background
Page-level retry for HTTP errors (429 rate limit, 5xx server errors) was already implemented. This PR adds retry for network-level failures that can occur mid-pagination.

## Changes
Retry on these transient network exceptions:
- `ConnectException` - connection refused, host unreachable
- `SocketException` - connection reset, broken pipe  
- `SocketTimeoutException` - read/connect timeout at socket level
- `TimeoutException` - general timeout (e.g., from http4s)
- `IOException` with "Connection reset" or "Broken pipe" message

Uses the same exponential backoff and `max-retries` config as HTTP error retry.

## Test plan
- [x] All 156 existing tests pass