### PR TITLE
Document pagination snapshot limitations

### DIFF
--- a/examples/github/github-config.conf
+++ b/examples/github/github-config.conf
@@ -59,6 +59,13 @@ auth {
 # Pagination
 # -----------------------------------------------------------------------------
 # Supported styles: link_header, cursor, offset, none
+#
+# IMPORTANT: Pagination does not provide snapshot isolation. Records may be
+# added, removed, or modified during a scan. This is inherent to REST API
+# pagination — the server returns whatever data exists at each page fetch.
+# For analytics requiring consistency, cache results locally first:
+#   spark.table("api.default.issues").cache()
+#
 pagination {
   style = "link_header"           # GitHub uses RFC 5988 Link headers
   page-size-param = "per_page"    # query param for page size


### PR DESCRIPTION
Closes #82

## Summary
- Add note to config reference explaining pagination does not guarantee snapshot isolation

## Changes
- Records may be added/removed during a scan
- Recommend caching locally for consistent analytics