### PR TITLE
Add OpenAPI 3.1 compatibility

### DIFF
--- a/src/main/scala/com/apilytics/core/openapi/Parser.scala
+++ b/src/main/scala/com/apilytics/core/openapi/Parser.scala
@@ -139,12 +139,18 @@ object Parser {
     }
 
     // OpenAPI 3.0 uses getType(), OpenAPI 3.1 uses getTypes() (array of types)
-    // For 3.1, we take the first non-null type from the array
+    // For 3.1 with multiple non-null types (union), return VariantType
     val tpe = Option(schema.getType).map(_.toString)
       .orElse {
         // OpenAPI 3.1: getTypes() returns Set<String> like ["string", "null"]
-        Option(schema.getTypes)
-          .map(_.asScala.filterNot(_ == "null").headOption.getOrElse("null"))
+        Option(schema.getTypes).flatMap { types =>
+          val nonNullTypes = types.asScala.filterNot(_ == "null").toList
+          nonNullTypes match {
+            case Nil         => Some("null")
+            case single :: Nil => Some(single)
+            case _           => None // Multiple types = union, will fall through to VariantType
+          }
+        }
       }
       .orElse(Option(schema.get$ref).map(_ => "object"))
     val hasProps = schema.getProperties != null && !schema.getProperties.isEmpty

--- a/src/test/scala/com/apilytics/core/openapi/ParserSuite.scala
+++ b/src/test/scala/com/apilytics/core/openapi/ParserSuite.scala
@@ -520,6 +520,42 @@ class ParserSuite extends FunSuite {
     assertEquals(result.endpoints.size, 1)
   }
 
+  test("OpenAPI 3.1: union type array produces VariantType") {
+    // In OpenAPI 3.1, type: ["string", "integer"] is a true union (not nullable)
+    // This should produce VariantType, not silently pick the first type
+    val spec =
+      """{
+        |  "openapi": "3.1.0",
+        |  "info": { "title": "Test", "version": "1.0" },
+        |  "paths": {
+        |    "/items": {
+        |      "get": {
+        |        "responses": {
+        |          "200": {
+        |            "content": {
+        |              "application/json": {
+        |                "schema": {
+        |                  "type": "object",
+        |                  "properties": {
+        |                    "id": { "type": "integer" },
+        |                    "value": { "type": ["string", "integer"] }
+        |                  }
+        |                }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val result = Parser.parseContent(spec)
+    val props = result.endpoints.head.responseSchema.properties
+    // Union of string|integer should be VariantType, not StringType
+    assertEquals(props("value"), OpenAPISchema.VariantType)
+  }
+
   test("OpenAPI 3.1: components/schemas references work") {
     // Use components/schemas (the standard OpenAPI way) instead of $defs
     val spec =


### PR DESCRIPTION
Closes #81

## Summary
- Fix parser to handle OpenAPI 3.1's JSON Schema 2020-12 dialect
- Add test coverage for 3.1-specific features

## Changes
**Parser fix:**
- Support `getTypes()` array - OpenAPI 3.1 uses `["string", "null"]` instead of `nullable: true`
- Take first non-null type from type arrays

**Tests added:**
- Type arrays with null (nullable fields)  
- `exclusiveMinimum` as number (not boolean)
- `const` values
- `components/schemas` references in 3.1 specs

## Known Limitation
`$defs` at root level is not supported by swagger-parser 2.1.x. Workaround: use `components/schemas` instead. This is documented in an ignored test.

## Test Plan
- [x] All existing OpenAPI 3.0 tests still pass
- [x] New 3.1 tests pass (6 new tests, 1 ignored with documented limitation)