### PR TITLE
Add Docker distribution image for zero-config quickstart

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Build JAR
+        run: sbt assembly
+
+      - name: Copy JAR to Docker context
+        run: cp target/scala-2.13/apilytics.jar docker/dist/
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: docker/dist
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ project/project/
 # Claude
 .claude/
 tmpclaude-*
+
+# Docker dist build artifacts
+docker/dist/apilytics.jar

--- a/README.md
+++ b/README.md
@@ -7,7 +7,39 @@
 
 Turn any REST API with an OpenAPI spec into queryable Apache Spark tables.
 
-## Quick Start
+## Quickstart
+
+Try Apilytics instantly with Docker - no Java, Scala, or build tools required:
+
+```bash
+# Query PokeAPI (no auth needed)
+docker run -it --rm ghcr.io/neutrinic/apilytics:latest \
+  "SELECT name FROM api.default.pokemon LIMIT 5"
+
+# Interactive spark-sql shell
+docker run -it --rm ghcr.io/neutrinic/apilytics:latest
+
+# With your own config file
+docker run -it --rm \
+  -v ./my-config.conf:/config.conf \
+  ghcr.io/neutrinic/apilytics:latest \
+  --config /config.conf
+```
+
+Bundled configs:
+- `pokeapi.conf` (default) - PokeAPI, no auth
+- `github-public.conf` - GitHub public repos, no auth (60 req/hour limit)
+
+```bash
+# Use GitHub public config
+docker run -it --rm ghcr.io/neutrinic/apilytics:latest \
+  --config /opt/apilytics/configs/github-public.conf \
+  "SELECT number, title FROM api.default.issues LIMIT 5"
+```
+
+## Development Setup
+
+For local development or contributing:
 
 ```bash
 # Build the JAR

--- a/docker/dist/Dockerfile
+++ b/docker/dist/Dockerfile
@@ -1,0 +1,49 @@
+# Apilytics Distribution Image
+# Pre-built image for zero-config quickstart
+#
+# Usage:
+#   docker run -it neutrinic/apilytics "SELECT name FROM api.default.pokemon LIMIT 5"
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+LABEL maintainer="Apilytics"
+LABEL org.opencontainers.image.source="https://github.com/Neutrinic/apilytics"
+LABEL org.opencontainers.image.description="Query REST APIs with Spark SQL"
+
+ARG SPARK_VERSION=4.0.0
+ARG JDK_VERSION=21
+
+# Install dependencies
+RUN microdnf update -y && \
+    microdnf install -y java-${JDK_VERSION}-openjdk-devel tar gzip curl procps && \
+    microdnf clean all
+
+# Environment variables
+ENV JAVA_HOME=/usr/lib/jvm/java-${JDK_VERSION}-openjdk
+ENV SPARK_HOME=/opt/spark
+ENV PATH=$PATH:$SPARK_HOME/bin
+
+# JVM options for Java 21 compatibility
+ENV SPARK_DAEMON_JAVA_OPTS="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED"
+ENV SPARK_SUBMIT_OPTS="$SPARK_DAEMON_JAVA_OPTS"
+
+# Download and install Spark
+RUN curl -L https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz | \
+    tar -xz -C /opt && \
+    ln -s /opt/spark-${SPARK_VERSION}-bin-hadoop3 ${SPARK_HOME}
+
+# Configure Spark
+RUN mkdir -p ${SPARK_HOME}/logs ${SPARK_HOME}/work
+
+# Copy Apilytics JAR (built externally and passed as build context)
+COPY apilytics.jar ${SPARK_HOME}/jars/
+
+# Copy bundled configs
+COPY configs/ /opt/apilytics/configs/
+
+# Copy entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /opt/spark
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/dist/configs/github-public.conf
+++ b/docker/dist/configs/github-public.conf
@@ -1,0 +1,42 @@
+# GitHub Public API Configuration for Apilytics
+# Works with public repositories without authentication
+# Note: Unauthenticated requests are rate-limited to 60/hour
+
+openapi = "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json"
+
+cache {
+  enabled = true
+  ttl = "24h"
+}
+
+auth {
+  type = none
+}
+
+pagination {
+  style = "link_header"
+  page-size-param = "per_page"
+  max-page-size = 100
+}
+
+http {
+  timeout = "30s"
+  max-retries = 3
+  max-backoff = "30s"
+}
+
+schema {
+  flatten-depth = 0
+  array-handling = "both"
+}
+
+tables {
+  issues {
+    endpoint = "/repos/octocat/Hello-World/issues"
+    filters = [
+      { param = "state", column = "state", operators = ["eq"] }
+      { param = "labels", column = "labels", operators = ["eq"] }
+      { param = "since", column = "created_at", operators = ["gte"] }
+    ]
+  }
+}

--- a/docker/dist/configs/pokeapi.conf
+++ b/docker/dist/configs/pokeapi.conf
@@ -1,0 +1,42 @@
+# PokeAPI Configuration for Apilytics
+# No authentication required - fully public API
+
+openapi = "https://raw.githubusercontent.com/PokeAPI/pokeapi/master/openapi.yml"
+
+auth {
+  type = none
+}
+
+pagination {
+  style = offset
+  offset-param = "offset"
+  page-size-param = "limit"
+  max-page-size = 100
+  results-path = "/results"
+}
+
+schema {
+  flatten-depth = 2
+  array-handling = both
+}
+
+http {
+  max-retries = 3
+  max-backoff = "10 seconds"
+  timeout = "30 seconds"
+}
+
+tables {
+  pokemon {
+    endpoint = "/api/v2/pokemon"
+    data-path = "/results"
+  }
+  types {
+    endpoint = "/api/v2/type"
+    data-path = "/results"
+  }
+  abilities {
+    endpoint = "/api/v2/ability"
+    data-path = "/results"
+  }
+}

--- a/docker/dist/entrypoint.sh
+++ b/docker/dist/entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+CONFIG_DIR="/opt/apilytics/configs"
+DEFAULT_CONFIG="$CONFIG_DIR/pokeapi.conf"
+
+# Parse arguments
+CONFIG_FILE="$DEFAULT_CONFIG"
+CATALOG_NAME="api"
+SQL_QUERY=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --config)
+      CONFIG_FILE="$2"
+      shift 2
+      ;;
+    --catalog)
+      CATALOG_NAME="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "Apilytics - Query REST APIs with Spark SQL"
+      echo ""
+      echo "Usage: docker run -it neutrinic/apilytics [OPTIONS] [SQL_QUERY]"
+      echo ""
+      echo "Options:"
+      echo "  --config FILE    Path to config file (default: pokeapi)"
+      echo "  --catalog NAME   Catalog name (default: api)"
+      echo "  -h, --help       Show this help message"
+      echo ""
+      echo "Examples:"
+      echo "  # Interactive shell with PokeAPI"
+      echo "  docker run -it neutrinic/apilytics"
+      echo ""
+      echo "  # Run a query"
+      echo "  docker run -it neutrinic/apilytics \"SELECT name FROM api.default.pokemon LIMIT 5\""
+      echo ""
+      echo "  # Use custom config"
+      echo "  docker run -it -v ./my.conf:/config.conf neutrinic/apilytics --config /config.conf"
+      echo ""
+      echo "Bundled configs:"
+      echo "  /opt/apilytics/configs/pokeapi.conf       - PokeAPI (default)"
+      echo "  /opt/apilytics/configs/github-public.conf - GitHub public repos"
+      exit 0
+      ;;
+    *)
+      SQL_QUERY="$1"
+      shift
+      ;;
+  esac
+done
+
+# Build spark-sql command (JAR is already in $SPARK_HOME/jars/, no --jars needed)
+SPARK_CMD="spark-sql"
+SPARK_CMD="$SPARK_CMD --conf spark.sql.catalog.$CATALOG_NAME=com.apilytics.spark.RESTCatalog"
+SPARK_CMD="$SPARK_CMD --conf spark.sql.catalog.$CATALOG_NAME.config=$CONFIG_FILE"
+
+# Run query or interactive shell
+if [[ -n "$SQL_QUERY" ]]; then
+  exec $SPARK_CMD -e "$SQL_QUERY"
+else
+  exec $SPARK_CMD
+fi


### PR DESCRIPTION
Closes #102

## Summary

Adds a pre-built Docker image that lets users try Apilytics instantly without cloning, building, or installing anything.

## Usage

```bash
# Query PokeAPI (no auth needed)
docker run -it --rm ghcr.io/neutrinic/apilytics:latest   "SELECT name FROM api.default.pokemon LIMIT 5"

# Interactive spark-sql shell
docker run -it --rm ghcr.io/neutrinic/apilytics:latest

# With custom config file
docker run -it --rm   -v ./my-config.conf:/config.conf   ghcr.io/neutrinic/apilytics:latest   --config /config.conf
```

## Changes

- `docker/dist/Dockerfile` - Extends base Spark image with pre-built JAR
- `docker/dist/entrypoint.sh` - Runs spark-sql with catalog configuration
- `docker/dist/configs/pokeapi.conf` - Default config, no auth needed
- `docker/dist/configs/github-public.conf` - GitHub public repos, no auth
- `.github/workflows/docker.yml` - Build and push to GHCR on main/tags
- `README.md` - Docker quickstart section at top of page

## Test plan

- [x] Docker build succeeds locally
- [x] `--help` flag works
- [x] PokeAPI query returns results
- [ ] GitHub Actions workflow builds and pushes to GHCR