### PR TITLE
Add COUNT(*) aggregation pushdown

### DIFF
--- a/examples/github/github-config.conf
+++ b/examples/github/github-config.conf
@@ -183,4 +183,30 @@ tables {
   #   batch-size = 100                        # max IDs per request (default: 100)
   #   batch-separator = ","                   # ID delimiter (default: ",")
   # }
+
+  # COUNT(*) aggregation pushdown example:
+  # For APIs that support getting counts without fetching all data,
+  # configure a count endpoint or count query parameter.
+  #
+  # Option 1: Dedicated count endpoint
+  # items {
+  #   endpoint = "/items"
+  #   count {
+  #     endpoint = "/items/count"           # separate count endpoint
+  #     response-path = "/total"            # JSON pointer to count value
+  #   }
+  # }
+  #
+  # Option 2: Query parameter that returns count
+  # items {
+  #   endpoint = "/items"
+  #   count {
+  #     param = "include"                   # query param name
+  #     param-value = "total_count"         # query param value (default: "true")
+  #     response-path = "/total_count"      # JSON pointer to count value
+  #   }
+  # }
+  #
+  # Usage: SELECT COUNT(*) FROM api.default.items
+  # -> Makes single request to count endpoint instead of fetching all pages
 }

--- a/src/main/scala/com/apilytics/core/config/Loader.scala
+++ b/src/main/scala/com/apilytics/core/config/Loader.scala
@@ -145,7 +145,8 @@ object Loader {
         batchParam = optional(tc, "batch-param"),
         batchSize = if (tc.hasPath("batch-size")) tc.getInt("batch-size") else 100,
         batchSeparator = if (tc.hasPath("batch-separator")) tc.getString("batch-separator") else ",",
-        childKeyField = optional(tc, "child-key-field")
+        childKeyField = optional(tc, "child-key-field"),
+        count = if (tc.hasPath("count")) Some(readCount(tc.getConfig("count"))) else None
       )
       
       // Validate batch join configuration
@@ -164,7 +165,18 @@ object Loader {
           )
         }
       }
-      
+
+      // Validate count config requires either endpoint or param
+      tableConfig.count.foreach { countConfig =>
+        if (countConfig.endpoint.isEmpty && countConfig.param.isEmpty) {
+          throw new IllegalArgumentException(
+            s"Table '$name' has count config but missing 'endpoint' or 'param'. " +
+            "Count pushdown requires either a dedicated count endpoint (e.g., endpoint = \"/items/count\") " +
+            "or a query parameter (e.g., param = \"include\", param-value = \"total_count\")."
+          )
+        }
+      }
+
       name -> tableConfig
     }.toMap
   }
@@ -192,6 +204,15 @@ object Loader {
       endParam = config.getString("end-param"),
       format = if (config.hasPath("format")) config.getString("format")
                else "yyyy-MM-dd'T'HH:mm:ss'Z'"
+    )
+  }
+
+  private def readCount(config: Config): CountConfig = {
+    CountConfig(
+      endpoint = optional(config, "endpoint"),
+      param = optional(config, "param"),
+      paramValue = if (config.hasPath("param-value")) config.getString("param-value") else "true",
+      responsePath = config.getString("response-path")
     )
   }
 

--- a/src/main/scala/com/apilytics/core/config/Models.scala
+++ b/src/main/scala/com/apilytics/core/config/Models.scala
@@ -133,6 +133,20 @@ object JoinStrategy {
   case object Batch extends JoinStrategy
 }
 
+/** Configuration for COUNT(*) aggregation pushdown. */
+final case class CountConfig(
+    /** Endpoint that returns the count (e.g., "/items/count").
+      * If not specified, uses the main endpoint with countParam. */
+    endpoint: Option[String] = None,
+    /** Query parameter to request count (e.g., "include" for ?include=total_count).
+      * Only used if endpoint is not specified. */
+    param: Option[String] = None,
+    /** Value for the count query parameter (default: "true"). */
+    paramValue: String = "true",
+    /** JSON pointer to extract count from response (e.g., "/total_count"). */
+    responsePath: String
+)
+
 final case class TableConfig(
     endpoint: String,
     dataPath: Option[String] = None,
@@ -153,7 +167,9 @@ final case class TableConfig(
     batchSeparator: String = ",",
     /** Field in child records that references the parent (batch join strategy).
       * Defaults to parentKey if not specified. */
-    childKeyField: Option[String] = None
+    childKeyField: Option[String] = None,
+    /** Configuration for COUNT(*) aggregation pushdown. */
+    count: Option[CountConfig] = None
 )
 
 final case class CacheConfig(

--- a/src/main/scala/com/apilytics/spark/CountInputPartition.scala
+++ b/src/main/scala/com/apilytics/spark/CountInputPartition.scala
@@ -1,0 +1,18 @@
+package com.apilytics.spark
+
+import com.apilytics.core.config.{CountConfig, SourceConfig, TableConfig}
+import org.apache.spark.sql.connector.read.InputPartition
+
+/** Input partition for COUNT(*) aggregation pushdown.
+  *
+  * Instead of fetching all data and counting locally, this partition
+  * calls a count endpoint or uses a count query parameter to get
+  * the count directly from the API.
+  */
+case class CountInputPartition(
+    tableConfig: TableConfig,
+    sourceConfig: SourceConfig,
+    baseUrl: String,
+    countConfig: CountConfig,
+    pushedParams: Map[String, String]
+) extends InputPartition

--- a/src/main/scala/com/apilytics/spark/CountPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/CountPartitionReader.scala
@@ -1,0 +1,87 @@
+package com.apilytics.spark
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.apilytics.core.http.Client
+import io.circe.Json
+import io.circe.pointer.Pointer
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.PartitionReader
+import org.http4s.Uri
+
+/** Partition reader for COUNT(*) aggregation pushdown.
+  *
+  * Makes a single HTTP request to the count endpoint and returns
+  * a single row with the count value.
+  *
+  * Note: Pushed filter params are forwarded as-is to the count endpoint.
+  * If the count endpoint doesn't support the same filter params as the
+  * main endpoint, you may get unexpected results or errors.
+  */
+class CountPartitionReader(partition: CountInputPartition) extends PartitionReader[InternalRow] {
+
+  private val count: Long = fetchCount()
+  private var returned = false
+
+  override def next(): Boolean = {
+    if (!returned) {
+      returned = true
+      true
+    } else {
+      false
+    }
+  }
+
+  override def get(): InternalRow = InternalRow(count)
+
+  override def close(): Unit = ()
+
+  private def fetchCount(): Long = {
+    val config = partition.countConfig
+
+    // Determine endpoint: use count endpoint if specified, otherwise main endpoint with param
+    val endpoint = config.endpoint.getOrElse(partition.tableConfig.endpoint)
+
+    // Build URI
+    val uri = Uri.unsafeFromString(partition.baseUrl + endpoint)
+
+    // Add count param if configured (when not using dedicated count endpoint)
+    val params: Map[String, String] = config.param match {
+      case Some(paramName) =>
+        partition.pushedParams + (paramName -> config.paramValue)
+      case None =>
+        partition.pushedParams
+    }
+
+    // Make request
+    val program: IO[Long] = Client
+      .resource(partition.sourceConfig.http, partition.sourceConfig.auth)
+      .use { client =>
+        client.get(uri, params).map { response =>
+          extractCount(response.json, config.responsePath)
+        }
+      }
+
+    program.unsafeRunSync()
+  }
+
+  /** Extract count value from JSON using JSON pointer. */
+  private def extractCount(json: Json, responsePath: String): Long = {
+    val pointer = Pointer.parse(responsePath).getOrElse(
+      throw new IllegalArgumentException(s"Invalid JSON pointer: $responsePath")
+    )
+
+    pointer.get(json) match {
+      case Right(countJson) =>
+        countJson.asNumber
+          .flatMap(_.toLong)
+          .getOrElse(throw new RuntimeException(
+            s"Count value at '$responsePath' is not a number: $countJson"
+          ))
+      case Left(_) =>
+        throw new RuntimeException(
+          s"Count field not found at '$responsePath' in response: $json"
+        )
+    }
+  }
+}

--- a/src/main/scala/com/apilytics/spark/RESTPartitionReaderFactory.scala
+++ b/src/main/scala/com/apilytics/spark/RESTPartitionReaderFactory.scala
@@ -6,15 +6,30 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class RESTPartitionReaderFactory extends PartitionReaderFactory {
 
-  override def supportColumnarReads(partition: InputPartition): Boolean = true
+  override def supportColumnarReads(partition: InputPartition): Boolean = {
+    // CountInputPartition returns a single row, use row-based reader
+    partition match {
+      case _: CountInputPartition => false
+      case _                      => true
+    }
+  }
 
   override def createColumnarReader(partition: InputPartition): PartitionReader[ColumnarBatch] = {
-    val p = partition.asInstanceOf[RESTInputPartition]
-    new RESTColumnarPartitionReader(p)
+    partition match {
+      case p: RESTInputPartition => new RESTColumnarPartitionReader(p)
+      case other => throw new IllegalArgumentException(
+        s"Columnar reader not supported for ${other.getClass.getSimpleName}"
+      )
+    }
   }
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
-    val p = partition.asInstanceOf[RESTInputPartition]
-    new RESTPartitionReader(p)
+    partition match {
+      case p: RESTInputPartition   => new RESTPartitionReader(p)
+      case p: CountInputPartition  => new CountPartitionReader(p)
+      case other => throw new IllegalArgumentException(
+        s"Unknown partition type: ${other.getClass.getSimpleName}"
+      )
+    }
   }
 }

--- a/src/main/scala/com/apilytics/spark/RESTScan.scala
+++ b/src/main/scala/com/apilytics/spark/RESTScan.scala
@@ -3,6 +3,7 @@ package com.apilytics.spark
 import com.apilytics.core.config.PartitionConfig
 import org.apache.arrow.vector.types.pojo.{Schema => ArrowSchema}
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.types.StructType
 
@@ -14,7 +15,8 @@ class RESTScan(
     arrowSchema: ArrowSchema,
     prunedSchema: Option[StructType],
     pushedParams: Map[String, String],
-    pushedLimit: Option[Int]
+    pushedLimit: Option[Int],
+    pushedAggregation: Option[Aggregation] = None
 ) extends Scan with Batch with Logging {
 
   // If pruned, return the pruned schema; otherwise return full schema
@@ -23,6 +25,35 @@ class RESTScan(
   override def toBatch(): Batch = this
 
   override def planInputPartitions(): Array[InputPartition] = {
+    // If aggregation is pushed, return a single count partition
+    pushedAggregation match {
+      case Some(_) =>
+        planCountPartition()
+      case None =>
+        planDataPartitions()
+    }
+  }
+
+  /** Plan a single partition for COUNT(*) aggregation. */
+  private def planCountPartition(): Array[InputPartition] = {
+    val tableConfig = table.tableConfig
+      .getOrElse(throw new IllegalStateException("COUNT(*) pushed but no table config"))
+    val countConfig = tableConfig.count
+      .getOrElse(throw new IllegalStateException("COUNT(*) pushed but no count config"))
+
+    logInfo("Planning COUNT(*) partition using count endpoint")
+
+    Array(CountInputPartition(
+      tableConfig = tableConfig,
+      sourceConfig = table.sourceConfig,
+      baseUrl = table.baseUrl,
+      countConfig = countConfig,
+      pushedParams = pushedParams
+    ))
+  }
+
+  /** Plan partitions for regular data reads. */
+  private def planDataPartitions(): Array[InputPartition] = {
     table.tableConfig.flatMap(_.partition) match {
       case Some(partitionConfig) =>
         planDateRangePartitions(partitionConfig)

--- a/src/main/scala/com/apilytics/spark/RESTScanBuilder.scala
+++ b/src/main/scala/com/apilytics/spark/RESTScanBuilder.scala
@@ -1,22 +1,80 @@
 package com.apilytics.spark
 
-import com.apilytics.core.config.FilterConfig
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownLimit, SupportsPushDownRequiredColumns, SupportsPushDownV2Filters}
+import com.apilytics.core.config.{CountConfig, FilterConfig}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, CountStar}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownLimit, SupportsPushDownRequiredColumns, SupportsPushDownV2Filters}
 import org.apache.spark.sql.types.StructType
 
 class RESTScanBuilder(table: RESTTable) extends ScanBuilder
     with SupportsPushDownV2Filters
     with SupportsPushDownLimit
     with SupportsPushDownRequiredColumns
-    with FilterPushdown {
+    with SupportsPushDownAggregates
+    with FilterPushdown
+    with Logging {
 
   private var prunedSchema: Option[StructType] = None
+  private var pushedAggregation: Option[Aggregation] = None
 
   override protected val filterConfigs: List[FilterConfig] =
     table.tableConfig.map(_.filters).getOrElse(Nil)
 
+  private val countConfig: Option[CountConfig] =
+    table.tableConfig.flatMap(_.count)
+
   override def pruneColumns(requiredSchema: StructType): Unit = {
     prunedSchema = Some(requiredSchema)
+  }
+
+  /** Push aggregation to the API if supported.
+    *
+    * We only support COUNT(*) when a count config is provided.
+    * The API must have either a dedicated count endpoint or a count query param.
+    */
+  override def pushAggregation(aggregation: Aggregation): Boolean = {
+    // Only support if count config is present
+    if (countConfig.isEmpty) {
+      logDebug("Aggregation pushdown rejected: no count config")
+      return false
+    }
+
+    // Only support COUNT(*) without GROUP BY
+    val aggs = aggregation.aggregateExpressions()
+    val groups = aggregation.groupByExpressions()
+
+    if (groups.nonEmpty) {
+      logDebug(s"Aggregation pushdown rejected: GROUP BY not supported (${groups.length} grouping columns)")
+      return false
+    }
+
+    if (aggs.length != 1) {
+      logDebug(s"Aggregation pushdown rejected: only single COUNT(*) supported (got ${aggs.length} aggregates)")
+      return false
+    }
+
+    aggs(0) match {
+      case _: CountStar =>
+        logInfo("Aggregation pushed to API: COUNT(*)")
+        pushedAggregation = Some(aggregation)
+        true
+      case other =>
+        logDebug(s"Aggregation pushdown rejected: unsupported aggregate function ${other.getClass.getSimpleName}")
+        false
+    }
+  }
+
+  /** Return true if we can fully compute the aggregation without Spark doing any post-aggregation.
+    *
+    * For COUNT(*) without GROUP BY, we return the exact count from the API, so Spark
+    * doesn't need to do any additional aggregation.
+    */
+  override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
+    // Complete pushdown only for COUNT(*) without GROUP BY
+    val groups = aggregation.groupByExpressions()
+    val aggs = aggregation.aggregateExpressions()
+
+    groups.isEmpty && aggs.length == 1 && aggs(0).isInstanceOf[CountStar] && countConfig.isDefined
   }
 
   override def build(): Scan = {
@@ -24,6 +82,6 @@ class RESTScanBuilder(table: RESTTable) extends ScanBuilder
       case Some(required) => ArrowSchemaConverter.pruneSchema(table.arrowSchema, required)
       case None           => table.arrowSchema
     }
-    new RESTScan(table, finalArrowSchema, prunedSchema, pushedParams, pushedLimit)
+    new RESTScan(table, finalArrowSchema, prunedSchema, pushedParams, pushedLimit, pushedAggregation)
   }
 }

--- a/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
@@ -1102,4 +1102,144 @@ class WireMockSuite extends FunSuite {
     server.verify(1, getRequestedFor(urlPathEqualTo("/tasks"))
       .withQueryParam("project_ids", equalTo("1,2")))
   }
+
+  // ============== COUNT AGGREGATION PUSHDOWN TESTS ===============
+
+  test("COUNT(*) pushdown uses count endpoint") {
+    // Count endpoint returns total count
+    server.stubFor(
+      get(urlPathEqualTo("/items/count"))
+        .willReturn(okJson("""{"total": 42}"""))
+    )
+
+    val countConfig = CountConfig(
+      endpoint = Some("/items/count"),
+      responsePath = "/total"
+    )
+
+    val tableConfig = TableConfig(
+      endpoint = "/items",
+      count = Some(countConfig)
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = CountInputPartition(
+      tableConfig = tableConfig,
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      countConfig = countConfig,
+      pushedParams = Map.empty
+    )
+
+    val reader = new CountPartitionReader(partition)
+
+    // Should have exactly one row
+    assert(reader.next())
+    val row = reader.get()
+    assertEquals(row.getLong(0), 42L)
+
+    // No more rows
+    assert(!reader.next())
+    reader.close()
+
+    // Verify count endpoint was called, not the main endpoint
+    server.verify(1, getRequestedFor(urlPathEqualTo("/items/count")))
+    server.verify(0, getRequestedFor(urlPathEqualTo("/items")))
+  }
+
+  test("COUNT(*) pushdown with query param") {
+    // Endpoint returns count when param is passed
+    server.stubFor(
+      get(urlPathEqualTo("/items"))
+        .withQueryParam("include", equalTo("total_count"))
+        .willReturn(okJson("""{"total_count": 100, "items": []}"""))
+    )
+
+    val countConfig = CountConfig(
+      param = Some("include"),
+      paramValue = "total_count",
+      responsePath = "/total_count"
+    )
+
+    val tableConfig = TableConfig(
+      endpoint = "/items",
+      count = Some(countConfig)
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = CountInputPartition(
+      tableConfig = tableConfig,
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      countConfig = countConfig,
+      pushedParams = Map.empty
+    )
+
+    val reader = new CountPartitionReader(partition)
+
+    assert(reader.next())
+    val row = reader.get()
+    assertEquals(row.getLong(0), 100L)
+    assert(!reader.next())
+    reader.close()
+
+    // Verify param was sent
+    server.verify(1, getRequestedFor(urlPathEqualTo("/items"))
+      .withQueryParam("include", equalTo("total_count")))
+  }
+
+  test("COUNT(*) pushdown includes pushed filter params") {
+    server.stubFor(
+      get(urlPathEqualTo("/items/count"))
+        .withQueryParam("status", equalTo("active"))
+        .willReturn(okJson("""{"count": 25}"""))
+    )
+
+    val countConfig = CountConfig(
+      endpoint = Some("/items/count"),
+      responsePath = "/count"
+    )
+
+    val tableConfig = TableConfig(
+      endpoint = "/items",
+      count = Some(countConfig)
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = CountInputPartition(
+      tableConfig = tableConfig,
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      countConfig = countConfig,
+      pushedParams = Map("status" -> "active")
+    )
+
+    val reader = new CountPartitionReader(partition)
+
+    assert(reader.next())
+    assertEquals(reader.get().getLong(0), 25L)
+    reader.close()
+
+    // Verify filter was passed to count endpoint
+    server.verify(1, getRequestedFor(urlPathEqualTo("/items/count"))
+      .withQueryParam("status", equalTo("active")))
+  }
 }

--- a/src/test/scala/com/apilytics/spark/ParentChildSuite.scala
+++ b/src/test/scala/com/apilytics/spark/ParentChildSuite.scala
@@ -234,6 +234,32 @@ class ParentChildSuite extends FunSuite {
     assertEquals(tableConfig.childKeyField, Some("proj_id"))
   }
 
+  test("Loader validates count config requires endpoint or param") {
+    import com.typesafe.config.ConfigFactory
+
+    val hocon = """
+      openapi = "test.yaml"
+      auth { type = "bearer", token = "test" }
+      http { timeout = "30s", max-backoff = "30s" }
+      tables {
+        items {
+          endpoint = "/items"
+          count {
+            response-path = "/total"
+          }
+        }
+      }
+    """
+
+    val error = intercept[IllegalArgumentException] {
+      Loader.load(ConfigFactory.parseString(hocon))
+    }
+
+    assert(error.getMessage.contains("count config"))
+    assert(error.getMessage.contains("endpoint"))
+    assert(error.getMessage.contains("param"))
+  }
+
   // --- ParentChildTable tests ---
 
   test("ParentChildTable extracts path parameter name from endpoint template") {


### PR DESCRIPTION
Closes #48

## Summary
- Add `SupportsPushDownAggregates` to `RESTScanBuilder`
- Support COUNT(*) pushdown via dedicated count endpoints or query params
- Single HTTP request returns count directly instead of fetching all pages

## Config
```hocon
tables {
  items {
    endpoint = "/items"
    count {
      endpoint = "/items/count"    # Option 1: dedicated endpoint
      response-path = "/total"
    }
  }
}
```

Or with query param:
```hocon
count {
  param = "include"
  param-value = "total_count"
  response-path = "/total_count"
}
```

## Usage
```sql
SELECT COUNT(*) FROM api.default.items
-- Makes 1 request to /items/count instead of paginating all data
```

## Test plan
- [x] 3 new WireMock tests for COUNT pushdown
- [x] All 207 existing tests pass