### PR TITLE
Add distributed rate limiting across partitions

### DIFF
--- a/src/main/scala/com/apilytics/core/config/Models.scala
+++ b/src/main/scala/com/apilytics/core/config/Models.scala
@@ -84,12 +84,15 @@ final case class HttpConfig(
     maxRetries: Int = 5,
     maxBackoff: FiniteDuration,
     timeout: FiniteDuration,
-    /** Maximum requests per second. None means no rate limiting.
+    /** Maximum requests per second (global limit). None means no rate limiting.
       *
-      * IMPORTANT: When using date-range partitioning, each partition runs in parallel
-      * with its own rate limiter. For example, with `rate-limit = 10` and 10 partitions,
-      * the effective rate is 100 rps (10 partitions × 10 rps each). Set this value to
-      * your API's rate limit divided by the expected number of partitions. */
+      * When using date-range partitioning, the configured rate limit is automatically
+      * distributed across partitions. For example, with `rate-limit = 100` and 10 partitions,
+      * each partition will be limited to 10 rps to maintain the overall 100 rps limit.
+      *
+      * Edge case: If the rate limit is less than the number of partitions (e.g., 5 rps with
+      * 10 partitions), each partition gets a minimum of 1 rps with a warning that the total
+      * may exceed the configured limit. */
     rateLimit: Option[Int] = None,
     /** Response caching configuration. */
     responseCache: ResponseCacheConfig = ResponseCacheConfig()

--- a/src/main/scala/com/apilytics/spark/CountInputPartition.scala
+++ b/src/main/scala/com/apilytics/spark/CountInputPartition.scala
@@ -14,5 +14,9 @@ case class CountInputPartition(
     sourceConfig: SourceConfig,
     baseUrl: String,
     countConfig: CountConfig,
-    pushedParams: Map[String, String]
+    pushedParams: Map[String, String],
+    /** Effective rate limit for this partition.
+      * For COUNT(*), this is typically the full configured limit since
+      * there's only one partition making a single request. */
+    effectiveRateLimit: Option[Int] = None
 ) extends InputPartition

--- a/src/main/scala/com/apilytics/spark/CountPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/CountPartitionReader.scala
@@ -53,9 +53,15 @@ class CountPartitionReader(partition: CountInputPartition) extends PartitionRead
         partition.pushedParams
     }
 
+    // Use effective rate limit (typically full limit for single COUNT partition)
+    val httpConfig = partition.effectiveRateLimit match {
+      case Some(_) => partition.sourceConfig.http.copy(rateLimit = partition.effectiveRateLimit)
+      case None    => partition.sourceConfig.http
+    }
+
     // Make request
     val program: IO[Long] = Client
-      .resource(partition.sourceConfig.http, partition.sourceConfig.auth)
+      .resource(httpConfig, partition.sourceConfig.auth)
       .use { client =>
         client.get(uri, params).map { response =>
           extractCount(response.json, config.responsePath)

--- a/src/main/scala/com/apilytics/spark/ParentChildColumnarPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/ParentChildColumnarPartitionReader.scala
@@ -35,11 +35,18 @@ class ParentChildColumnarPartitionReader(partition: ParentChildInputPartition)
   override protected lazy val allocator: RootAllocator = new RootAllocator()
   override protected lazy val arrowSchema: ArrowSchema = ArrowSchema.fromJSON(partition.arrowSchemaJson)
 
-  // Use singleton cache that persists across queries on this executor
-  private val responseCache = ResponseCache.fromConfig(partition.sourceConfig.http.responseCache)
+  // Use lazy vals to avoid initialization order issues with LazyColumnarReader's constructor
+  // which starts a fiber that may access these before they're initialized
+  private lazy val responseCache = ResponseCache.fromConfig(partition.sourceConfig.http.responseCache)
+
+  // Use effective rate limit calculated by ParentChildScan (distributed across partitions)
+  private lazy val httpConfig = partition.effectiveRateLimit match {
+    case Some(_) => partition.sourceConfig.http.copy(rateLimit = partition.effectiveRateLimit)
+    case None    => partition.sourceConfig.http
+  }
 
   override protected def clientResource: Resource[IO, Client.RestClient] =
-    Client.resource(partition.sourceConfig.http, partition.sourceConfig.auth, responseCache)
+    Client.resource(httpConfig, partition.sourceConfig.auth, responseCache)
 
   override protected def buildStream(
       client: Client.RestClient

--- a/src/main/scala/com/apilytics/spark/ParentChildInputPartition.scala
+++ b/src/main/scala/com/apilytics/spark/ParentChildInputPartition.scala
@@ -16,5 +16,8 @@ case class ParentChildInputPartition(
     baseUrl: String,
     arrowSchemaJson: String,
     pushedParams: Map[String, String] = Map.empty,
-    pushedLimit: Option[Int] = None
+    pushedLimit: Option[Int] = None,
+    /** Effective rate limit for this partition (configured limit / number of partitions).
+      * Automatically distributed by ParentChildScan to prevent exceeding API limits. */
+    effectiveRateLimit: Option[Int] = None
 ) extends InputPartition

--- a/src/main/scala/com/apilytics/spark/ParentChildPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/ParentChildPartitionReader.scala
@@ -48,8 +48,14 @@ class ParentChildPartitionReader(partition: ParentChildInputPartition) extends P
     val batchSize = partition.sourceConfig.schema.arrowBatchSize
     val joinStrategy = partition.tableConfig.joinStrategy.getOrElse(JoinStrategy.NestedLoop)
 
+    // Use effective rate limit calculated by ParentChildScan (distributed across partitions)
+    val httpConfig = partition.effectiveRateLimit match {
+      case Some(_) => partition.sourceConfig.http.copy(rateLimit = partition.effectiveRateLimit)
+      case None    => partition.sourceConfig.http
+    }
+
     val program: IO[List[InternalRow]] = Client
-      .resource(partition.sourceConfig.http, partition.sourceConfig.auth)
+      .resource(httpConfig, partition.sourceConfig.auth)
       .use { client =>
         // Fetch parent records
         val parentPages = Paginator.pages(

--- a/src/main/scala/com/apilytics/spark/ParentChildScan.scala
+++ b/src/main/scala/com/apilytics/spark/ParentChildScan.scala
@@ -16,7 +16,10 @@ class ParentChildScan(
 
   override def toBatch(): Batch = this
 
-  override def planInputPartitions(): Array[InputPartition] =
+  override def planInputPartitions(): Array[InputPartition] = {
+    // Single partition for parent-child tables gets the full rate limit
+    val effectiveRateLimit = table.sourceConfig.http.rateLimit
+
     Array(ParentChildInputPartition(
       childEndpointTemplate = table.childEndpointTemplate,
       parentEndpoint = table.parentEndpoint,
@@ -29,8 +32,10 @@ class ParentChildScan(
       baseUrl = table.baseUrl,
       arrowSchemaJson = arrowSchema.toJson,
       pushedParams = pushedParams,
-      pushedLimit = pushedLimit
+      pushedLimit = pushedLimit,
+      effectiveRateLimit = effectiveRateLimit
     ))
+  }
 
   override def createReaderFactory(): PartitionReaderFactory =
     new ParentChildPartitionReaderFactory()

--- a/src/main/scala/com/apilytics/spark/RESTColumnarPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/RESTColumnarPartitionReader.scala
@@ -20,8 +20,14 @@ class RESTColumnarPartitionReader(partition: RESTInputPartition) extends LazyCol
   // Use singleton cache that persists across queries on this executor
   private val responseCache = ResponseCache.fromConfig(partition.sourceConfig.http.responseCache)
 
+  // Use effective rate limit calculated by RESTScan (distributed across partitions)
+  private val httpConfig = partition.effectiveRateLimit match {
+    case Some(_) => partition.sourceConfig.http.copy(rateLimit = partition.effectiveRateLimit)
+    case None    => partition.sourceConfig.http
+  }
+
   override protected def clientResource: Resource[IO, Client.RestClient] =
-    Client.resource(partition.sourceConfig.http, partition.sourceConfig.auth, responseCache)
+    Client.resource(httpConfig, partition.sourceConfig.auth, responseCache)
 
   override protected def buildStream(
       client: Client.RestClient

--- a/src/main/scala/com/apilytics/spark/RESTInputPartition.scala
+++ b/src/main/scala/com/apilytics/spark/RESTInputPartition.scala
@@ -11,5 +11,8 @@ case class RESTInputPartition(
     baseUrl: String,
     arrowSchemaJson: String,
     pushedParams: Map[String, String],
-    pushedLimit: Option[Int]
+    pushedLimit: Option[Int],
+    /** Effective rate limit for this partition (configured limit / number of partitions).
+      * Automatically distributed by RESTScan to prevent exceeding API limits. */
+    effectiveRateLimit: Option[Int] = None
 ) extends InputPartition

--- a/src/main/scala/com/apilytics/spark/RESTPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/RESTPartitionReader.scala
@@ -41,8 +41,14 @@ class RESTPartitionReader(partition: RESTInputPartition) extends PartitionReader
     val baseUri = Uri.unsafeFromString(partition.baseUrl + partition.endpoint.path)
     val dataPath = partition.tableConfig.flatMap(_.dataPath)
 
+    // Use effective rate limit calculated by RESTScan (distributed across partitions)
+    val httpConfig = partition.effectiveRateLimit match {
+      case Some(_) => partition.sourceConfig.http.copy(rateLimit = partition.effectiveRateLimit)
+      case None    => partition.sourceConfig.http
+    }
+
     val program: IO[List[InternalRow]] = Client
-      .resource(partition.sourceConfig.http, partition.sourceConfig.auth)
+      .resource(httpConfig, partition.sourceConfig.auth)
       .use { client =>
         Paginator
           .pages(client, baseUri, partition.pushedParams, partition.sourceConfig.pagination, partition.pushedLimit)

--- a/src/main/scala/com/apilytics/spark/RESTScan.scala
+++ b/src/main/scala/com/apilytics/spark/RESTScan.scala
@@ -43,12 +43,16 @@ class RESTScan(
 
     logInfo("Planning COUNT(*) partition using count endpoint")
 
+    // Single partition gets full rate limit
+    val effectiveRateLimit = table.sourceConfig.http.rateLimit
+
     Array(CountInputPartition(
       tableConfig = tableConfig,
       sourceConfig = table.sourceConfig,
       baseUrl = table.baseUrl,
       countConfig = countConfig,
-      pushedParams = pushedParams
+      pushedParams = pushedParams,
+      effectiveRateLimit = effectiveRateLimit
     ))
   }
 
@@ -58,7 +62,8 @@ class RESTScan(
       case Some(partitionConfig) =>
         planDateRangePartitions(partitionConfig)
       case None =>
-        // No partitioning configured - single partition
+        // No partitioning configured - single partition gets full rate limit
+        val effectiveRateLimit = table.sourceConfig.http.rateLimit
         Array(RESTInputPartition(
           endpoint = table.endpoint,
           tableConfig = table.tableConfig,
@@ -66,7 +71,8 @@ class RESTScan(
           baseUrl = table.baseUrl,
           arrowSchemaJson = arrowSchema.toJson,
           pushedParams = pushedParams,
-          pushedLimit = pushedLimit
+          pushedLimit = pushedLimit,
+          effectiveRateLimit = effectiveRateLimit
         ))
     }
   }
@@ -110,7 +116,16 @@ class RESTScan(
         logInfo("Date range is empty (start >= end), returning empty partition list")
         Some(Array.empty)
       } else {
-        logInfo(s"Partitioning into ${ranges.size} date ranges (${config.range} each)")
+        val numPartitions = ranges.size
+        val effectiveRateLimit = calculateEffectiveRateLimit(numPartitions)
+
+        effectiveRateLimit match {
+          case Some(limit) =>
+            logInfo(s"Partitioning into $numPartitions date ranges (${config.range} each), " +
+              s"rate limit distributed: ${table.sourceConfig.http.rateLimit.get} / $numPartitions = $limit rps per partition")
+          case None =>
+            logInfo(s"Partitioning into $numPartitions date ranges (${config.range} each)")
+        }
 
         Some(ranges.map { case (rangeStart, rangeEnd) =>
           val startStr = formatter.format(Instant.ofEpochMilli(rangeStart))
@@ -128,7 +143,8 @@ class RESTScan(
             baseUrl = table.baseUrl,
             arrowSchemaJson = arrowSchema.toJson,
             pushedParams = partitionParams,
-            pushedLimit = pushedLimit
+            pushedLimit = pushedLimit,
+            effectiveRateLimit = effectiveRateLimit
           )
         }.toArray)
       }
@@ -142,6 +158,8 @@ class RESTScan(
 
   /** Single partition fallback when partitioning cannot be applied. */
   private def singlePartitionFallback(): Array[InputPartition] = {
+    // Single partition gets full rate limit
+    val effectiveRateLimit = table.sourceConfig.http.rateLimit
     Array(RESTInputPartition(
       endpoint = table.endpoint,
       tableConfig = table.tableConfig,
@@ -149,7 +167,8 @@ class RESTScan(
       baseUrl = table.baseUrl,
       arrowSchemaJson = arrowSchema.toJson,
       pushedParams = pushedParams,
-      pushedLimit = pushedLimit
+      pushedLimit = pushedLimit,
+      effectiveRateLimit = effectiveRateLimit
     ))
   }
 
@@ -164,6 +183,28 @@ class RESTScan(
         Some(((s, rangeEnd), rangeEnd))
       }
     }.toList
+  }
+
+  /** Calculate effective rate limit per partition.
+    *
+    * Divides the configured rate limit by the number of partitions to prevent
+    * exceeding the API's global rate limit when partitions run in parallel.
+    *
+    * @param numPartitions Number of partitions that will run in parallel
+    * @return Effective rate limit per partition, or None if no rate limit configured
+    */
+  private def calculateEffectiveRateLimit(numPartitions: Int): Option[Int] = {
+    table.sourceConfig.http.rateLimit.flatMap { configuredLimit =>
+      val perPartition = configuredLimit / numPartitions
+      if (perPartition > 0) {
+        Some(perPartition)
+      } else {
+        // Rate limit is lower than partition count - use minimum of 1 rps
+        logWarning(s"Configured rate limit ($configuredLimit rps) is less than partition count " +
+          s"($numPartitions). Using minimum of 1 rps per partition, which may exceed API limits.")
+        Some(1)
+      }
+    }
   }
 
   override def createReaderFactory(): PartitionReaderFactory =


### PR DESCRIPTION
Closes #43

## Summary
- Automatically divide configured rate limit by partition count when using date-range partitioning
- Previously each partition ran with full rate limit (e.g., 10 partitions × 100 rps = 1000 rps total, exceeding API limit)
- Now `rate-limit = 100` with 10 partitions → each partition gets 10 rps
- Edge case: if rate limit < partition count, use minimum 1 rps with warning

## Test plan
- [x] All 204 existing tests pass
- [x] Compile succeeds
- [ ] Manual test: set rate-limit=10, create 5 partitions via date-range, verify each partition requests at ~2 rps