### PR TITLE
Fix release workflow: add sbt setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Publish to Maven Central
         run: sbt ci-release


### PR DESCRIPTION
Closes #116

## Summary
- Add `sbt/setup-sbt@v1` to install sbt
- Add `cache: sbt` for faster builds

The previous release workflow failed because sbt wasn't installed.