### PR TITLE
Add Spark Thrift Server for JDBC access

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,21 +104,24 @@ withCleanErrors {
 
 ### Exploring Catalogs
 
-Catalogs are registered at startup, but won't appear in `SHOW CATALOGS` until you query them. Use these commands to explore:
+Catalogs are lazily loaded - they won't appear in `SHOW CATALOGS` until first accessed. To discover available catalogs and tables:
 
-```scala
-// List namespaces in a catalog
-spark.sql("SHOW NAMESPACES IN api").show()
+```sql
+-- Touch the catalog to register it (any query works)
+SHOW NAMESPACES IN api;
 
-// List tables in a namespace
-spark.sql("SHOW TABLES IN api.default").show()
+-- Now it appears in SHOW CATALOGS
+SHOW CATALOGS;
 
-// Describe a table's schema
-spark.sql("DESCRIBE api.default.issues").show()
+-- List tables (always use <catalog>.default.<table> format)
+SHOW TABLES IN api.default;
 
-// Extended table info
-spark.sql("DESCRIBE EXTENDED api.default.issues").show()
+-- Describe schema
+DESCRIBE api.default.issues;
+DESCRIBE EXTENDED api.default.issues;
 ```
+
+**Important**: Always use the full path `<catalog>.default.<table>` format. Using just `<catalog>.<table>` won't work - the `default` namespace is required.
 
 ### Multiple Catalogs
 
@@ -129,13 +132,17 @@ You can load multiple APIs as separate catalogs:
 ./scripts/spark-shell.sh multi
 ```
 
-```scala
-// Query across catalogs
-spark.sql("SHOW TABLES IN github.default").show()
-spark.sql("SHOW TABLES IN pokemon.default").show()
+```sql
+-- Touch each catalog to register it
+SHOW NAMESPACES IN github;
+SHOW NAMESPACES IN pokemon;
 
-spark.sql("SELECT number, title FROM github.default.issues LIMIT 5").show()
-spark.sql("SELECT name, url FROM pokemon.default.pokemon LIMIT 5").show()
+-- Now both appear
+SHOW CATALOGS;
+
+-- Query tables (always use <catalog>.default.<table>)
+SELECT number, title FROM github.default.issues LIMIT 5;
+SELECT name, url FROM pokemon.default.pokemon LIMIT 5;
 ```
 
 To configure multiple catalogs manually:
@@ -148,7 +155,39 @@ spark-shell \
   --conf "spark.sql.catalog.slack.config=/path/to/slack-config.conf"
 ```
 
-Then query with `github.default.*` and `slack.default.*`.
+### JDBC Access (DBeaver, Tableau, PowerBI)
+
+Connect BI tools via standard JDBC using the Thrift Server:
+
+```bash
+cd docker/spark
+docker compose -f compose.spark.yaml up -d
+```
+
+**Connection Details:**
+- **Driver**: Apache Hive JDBC
+- **URL**: `jdbc:hive2://localhost:10000`
+- **Username**: any (e.g., "spark")
+- **Password**: empty
+
+**DBeaver Setup:**
+1. New Connection > Apache Hive
+2. Host: localhost, Port: 10000
+3. Test Connection
+
+**Configure Multiple Catalogs** in `compose.spark.yaml`:
+```yaml
+environment:
+  - CATALOGS=github,pokemon
+  - CATALOG_GITHUB_CONFIG=/opt/spark/examples/github/github-config.conf
+  - CATALOG_POKEMON_CONFIG=/opt/spark/examples/pokeapi/pokeapi-config.conf
+```
+
+Then query with catalog prefix:
+```sql
+SELECT * FROM github.default.issues LIMIT 10;
+SELECT * FROM pokemon.default.pokemon LIMIT 10;
+```
 
 ## Overview
 

--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -34,8 +34,8 @@ VOLUME ["/opt/spark/logs", "/opt/spark/work", "/opt/spark/spark-events"]
 
 # Ports
 # 8080: Master WebUI, 7077: Master port, 8081: Worker WebUI
-# 18080: History Server, 4040: Application UI
-EXPOSE 8080 7077 8081 18080 4040
+# 18080: History Server, 4040: Application UI, 10000: Thrift/JDBC
+EXPOSE 8080 7077 8081 18080 4040 10000
 
 # Entrypoint script
 RUN chmod +x /entrypoint.sh

--- a/docker/spark/compose.spark.yaml
+++ b/docker/spark/compose.spark.yaml
@@ -76,6 +76,30 @@ services:
     networks:
       - apilytics-net
 
+# JDBC: jdbc:hive2://localhost:10000
+  spark-thrift:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: spark-thrift
+    hostname: spark-thrift
+    environment:
+      - SPARK_ROLE=thriftserver
+      - SPARK_MASTER_URL=spark://spark-master:7077
+      # Configure catalogs: CATALOGS=api,github and CATALOG_<NAME>_CONFIG=path
+      - CATALOGS=api
+      - CATALOG_API_CONFIG=/opt/spark/examples/pokeapi/pokeapi-config.conf
+    volumes:
+      - spark-events:/opt/spark/spark-events
+      - ../../target/scala-2.13/apilytics.jar:/opt/spark/jars/apilytics.jar:ro
+      - ../../examples:/opt/spark/examples:ro
+    ports:
+      - "10000:10000"
+    depends_on:
+      - spark-master
+    networks:
+      - apilytics-net
+
 volumes:
   spark-events: {}
 

--- a/docker/spark/entrypoint.sh
+++ b/docker/spark/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 role=${SPARK_ROLE:-""}
 
 if [ -z "$role" ]; then
-    echo "SPARK_ROLE must be set: master, worker, history"
+    echo "SPARK_ROLE must be set: master, worker, history, thriftserver"
     exit 1
 fi
 
@@ -27,6 +27,34 @@ case $role in
         ;;
     history)
         exec ${SPARK_HOME}/bin/spark-class org.apache.spark.deploy.history.HistoryServer
+        ;;
+    thriftserver)
+        # Build catalog conf arguments from environment variables
+        # CATALOGS=api,github,pokemon
+        # CATALOG_API_CONFIG=/path/to/config.conf
+        CATALOG_CONFS=""
+        if [ -n "$CATALOGS" ]; then
+            OLD_IFS="$IFS"
+            IFS=','
+            for catalog in $CATALOGS; do
+                upper=$(echo "$catalog" | tr '[:lower:]' '[:upper:]')
+                config_path=$(printenv "CATALOG_${upper}_CONFIG")
+                if [ -n "$config_path" ]; then
+                    CATALOG_CONFS="$CATALOG_CONFS --conf spark.sql.catalog.${catalog}=com.apilytics.spark.RESTCatalog"
+                    CATALOG_CONFS="$CATALOG_CONFS --conf spark.sql.catalog.${catalog}.config=${config_path}"
+                fi
+            done
+            IFS="$OLD_IFS"
+        fi
+
+        exec ${SPARK_HOME}/bin/spark-submit \
+            --class org.apache.spark.sql.hive.thriftserver.HiveThriftServer2 \
+            --name "Thrift JDBC/ODBC Server" \
+            --master ${SPARK_MASTER_URL:-local[*]} \
+            --hiveconf hive.server2.thrift.port=10000 \
+            --hiveconf hive.server2.thrift.bind.host=0.0.0.0 \
+            $CATALOG_CONFS \
+            spark-internal
         ;;
     *)
         echo "Unknown role: $role"

--- a/docker/spark/spark-defaults.conf
+++ b/docker/spark/spark-defaults.conf
@@ -1,3 +1,8 @@
 spark.eventLog.enabled           true
 spark.eventLog.dir               file:///opt/spark/spark-events
 spark.history.fs.logDirectory    file:///opt/spark/spark-events
+
+# Thrift Server / Hive metastore (in-memory Derby for read-only catalogs)
+spark.sql.warehouse.dir                                    /tmp/spark-warehouse
+spark.hadoop.javax.jdo.option.ConnectionURL                jdbc:derby:memory:metastore_db;create=true
+spark.hadoop.javax.jdo.option.ConnectionDriverName         org.apache.derby.jdbc.EmbeddedDriver

--- a/src/main/scala/com/apilytics/spark/RESTCatalog.scala
+++ b/src/main/scala/com/apilytics/spark/RESTCatalog.scala
@@ -242,9 +242,13 @@ class RESTCatalog extends CatalogPlugin with TableCatalog with SupportsNamespace
 
   private def tableNames: Seq[String] = {
     val configured = config.tables.keys.toSeq
-    val discovered = spec.endpoints.flatMap { ep =>
-      ep.operationId.orElse(ep.path.split("/").filterNot(s => s.startsWith("{") || s.isEmpty).lastOption)
-    }
+    // Only auto-discover endpoints without path parameters (e.g., /pokemon but not /pokemon/{id})
+    // Endpoints with path parameters require parent-child config to substitute values
+    val discovered = spec.endpoints
+      .filterNot(_.path.contains("{"))
+      .flatMap { ep =>
+        ep.operationId.orElse(ep.path.split("/").filterNot(_.isEmpty).lastOption)
+      }
     val baseTables = (configured ++ discovered).distinct
 
     // Generate exploded view names if array-handling is explode_view or both


### PR DESCRIPTION
Closes #121

## Summary
- Add `thriftserver` role to entrypoint.sh with dynamic catalog configuration via env vars
- Add `spark-thrift` service to compose.spark.yaml (port 10000)
- Configure Derby in-memory metastore for Hive compatibility
- Skip auto-discovery of parameterized endpoints (e.g., `/pokemon/{id}`)
- Document JDBC connection setup and catalog behavior in README

## Usage
```bash
cd docker/spark
docker compose -f compose.spark.yaml up -d
```

Connect with DBeaver/Tableau/PowerBI:
- Driver: Apache Hive JDBC
- URL: `jdbc:hive2://localhost:10000`

## Changes
- `docker/spark/entrypoint.sh` - Add thriftserver role
- `docker/spark/compose.spark.yaml` - Add spark-thrift service
- `docker/spark/spark-defaults.conf` - Add metastore config
- `docker/spark/Dockerfile` - Expose port 10000
- `src/main/scala/.../RESTCatalog.scala` - Skip endpoints with path params in auto-discovery
- `README.md` - Document JDBC access and catalog behavior

## Test plan
- [x] Build and start thrift server
- [x] Connect with beeline
- [x] Connect with IntelliJ Database Tools
- [x] Query PokeAPI tables
- [ ] Test with DBeaver (optional)