### PR TITLE
Add configurable aggregation pushdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ APIlytics is a Spark DataSource V2 catalog plugin that reads OpenAPI 3.x specifi
 - **Authentication** - bearer token, basic auth, custom headers, OAuth2 client credentials
 - **Filter pushdown** - Spark SQL filters map to API query parameters
 - **Limit pushdown** - stops pagination early when a LIMIT clause is present
-- **COUNT(*) pushdown** - single API call for counts when count endpoint configured
+- **Aggregation pushdown** - SUM, AVG, MIN, MAX, COUNT, and custom functions push to API endpoints
 - **Schema flattening** - nested objects flatten to a configurable depth, deeper nesting falls back to VARIANT
 - **Arrow internals** - zero-copy path to Spark ColumnarBatch
 - **Parent-child joins** - chain API calls (e.g., fetch issues then comments for each)

--- a/examples/github/github-config.conf
+++ b/examples/github/github-config.conf
@@ -1,8 +1,10 @@
 # =============================================================================
 # APIlytics Configuration Reference
 # =============================================================================
-# This file serves as both a working GitHub example and documentation for all
-# available configuration options.
+# This file documents ALL available configuration options. It uses GitHub as
+# an example, but GitHub's API doesn't support every feature shown here
+# (e.g., aggregation endpoints, batch joins). Options that don't apply to
+# GitHub are shown as commented examples.
 #
 # Usage:
 #   export GITHUB_TOKEN=ghp_xxxxx  # optional, for higher rate limits
@@ -224,29 +226,68 @@ tables {
   # divided across partitions. With rate-limit=100 and 5 partitions, each
   # partition gets 20 rps to maintain the overall 100 rps limit.
 
-  # COUNT(*) aggregation pushdown example:
-  # For APIs that support getting counts without fetching all data,
-  # configure a count endpoint or count query parameter.
+  # ---------------------------------------------------------------------------
+  # Aggregation Pushdown
+  # ---------------------------------------------------------------------------
+  # For APIs that support server-side aggregations, configure endpoints for
+  # each aggregate function. Apilytics pushes SUM, AVG, MIN, MAX, COUNT to
+  # the API instead of fetching all data.
   #
-  # Option 1: Dedicated count endpoint
-  # items {
-  #   endpoint = "/items"
-  #   count {
-  #     endpoint = "/items/count"           # separate count endpoint
-  #     response-path = "/total"            # JSON pointer to count value
+  # Standard aggregations:
+  # orders {
+  #   endpoint = "/orders"
+  #   aggregations {
+  #     total_amount {
+  #       function = "sum"                  # sum, avg, min, max, count
+  #       column = "amount"                 # required for sum/avg/min/max
+  #       endpoint = "/orders/stats"        # aggregation endpoint
+  #       response-path = "/total"          # JSON pointer to result
+  #     }
+  #     avg_amount {
+  #       function = "avg"
+  #       column = "amount"
+  #       endpoint = "/orders/stats"
+  #       response-path = "/average"
+  #     }
+  #     order_count {
+  #       function = "count"                # COUNT(*) - column not required
+  #       endpoint = "/orders/count"
+  #       response-path = "/count"
+  #     }
   #   }
   # }
   #
-  # Option 2: Query parameter that returns count
-  # items {
-  #   endpoint = "/items"
-  #   count {
-  #     param = "include"                   # query param name
-  #     param-value = "total_count"         # query param value (default: "true")
-  #     response-path = "/total_count"      # JSON pointer to count value
+  # Custom aggregations (percentiles, quartiles, etc.):
+  # orders {
+  #   endpoint = "/orders"
+  #   aggregations {
+  #     amount_p95 {
+  #       function = "custom"
+  #       name = "PERCENTILE"               # function name for SQL
+  #       endpoint = "/orders/percentiles"
+  #       response-path = "/p95"
+  #       params {                          # additional query params
+  #         percentile = "95"
+  #         column = "amount"
+  #       }
+  #     }
   #   }
   # }
   #
-  # Usage: SELECT COUNT(*) FROM api.default.items
-  # -> Makes single request to count endpoint instead of fetching all pages
+  # Usage:
+  #   SELECT SUM(amount), AVG(amount) FROM api.default.orders
+  #   -> Makes requests to /orders/stats for each aggregate
+  #
+  # Pushed filter params are merged with aggregation params:
+  #   SELECT SUM(amount) FROM api.default.orders WHERE status = 'completed'
+  #   -> GET /orders/stats?status=completed
+  #
+  # Legacy COUNT(*) config (still supported):
+  # items {
+  #   endpoint = "/items"
+  #   count {
+  #     endpoint = "/items/count"
+  #     response-path = "/total"
+  #   }
+  # }
 }

--- a/src/main/scala/com/apilytics/core/config/Loader.scala
+++ b/src/main/scala/com/apilytics/core/config/Loader.scala
@@ -146,7 +146,9 @@ object Loader {
         batchSize = if (tc.hasPath("batch-size")) tc.getInt("batch-size") else 100,
         batchSeparator = if (tc.hasPath("batch-separator")) tc.getString("batch-separator") else ",",
         childKeyField = optional(tc, "child-key-field"),
-        count = if (tc.hasPath("count")) Some(readCount(tc.getConfig("count"))) else None
+        count = if (tc.hasPath("count")) Some(readCount(tc.getConfig("count"))) else None,
+        aggregations = if (tc.hasPath("aggregations")) readAggregations(tc.getConfig("aggregations"))
+                       else Map.empty
       )
       
       // Validate batch join configuration
@@ -241,6 +243,51 @@ object Loader {
       paramValue = if (config.hasPath("param-value")) config.getString("param-value") else "true",
       responsePath = config.getString("response-path")
     )
+  }
+
+  private def readAggregations(config: Config): Map[String, AggregationConfig] = {
+    config.root().keySet().asScala.map { name =>
+      val ac = config.getConfig(name)
+      val function = ac.getString("function") match {
+        case "count"  => AggregationFunction.Count
+        case "sum"    => AggregationFunction.Sum
+        case "avg"    => AggregationFunction.Avg
+        case "min"    => AggregationFunction.Min
+        case "max"    => AggregationFunction.Max
+        case "custom" =>
+          val customName = if (ac.hasPath("name")) ac.getString("name")
+                           else throw new IllegalArgumentException(
+                             s"Aggregation '$name' has function=custom but missing 'name' field"
+                           )
+          AggregationFunction.Custom(customName)
+        case other => throw new IllegalArgumentException(s"Unknown aggregation function: $other")
+      }
+
+      val aggConfig = AggregationConfig(
+        function = function,
+        column = optional(ac, "column"),
+        endpoint = ac.getString("endpoint"),
+        responsePath = ac.getString("response-path"),
+        params = if (ac.hasPath("params")) {
+          val paramsConfig = ac.getConfig("params")
+          paramsConfig.root().keySet().asScala.map { key =>
+            key -> paramsConfig.getString(key)
+          }.toMap
+        } else Map.empty
+      )
+
+      // Validate column is required for sum/avg/min/max
+      function match {
+        case AggregationFunction.Sum | AggregationFunction.Avg |
+             AggregationFunction.Min | AggregationFunction.Max if aggConfig.column.isEmpty =>
+          throw new IllegalArgumentException(
+            s"Aggregation '$name' with function=${ac.getString("function")} requires 'column' field"
+          )
+        case _ => // OK
+      }
+
+      name -> aggConfig
+    }.toMap
   }
 
   private def optional(config: Config, path: String): Option[String] =

--- a/src/main/scala/com/apilytics/core/config/Models.scala
+++ b/src/main/scala/com/apilytics/core/config/Models.scala
@@ -150,7 +150,9 @@ object JoinStrategy {
   case object Batch extends JoinStrategy
 }
 
-/** Configuration for COUNT(*) aggregation pushdown. */
+/** Configuration for COUNT(*) aggregation pushdown.
+  * @deprecated Use AggregationConfig with function="count" instead.
+  */
 final case class CountConfig(
     /** Endpoint that returns the count (e.g., "/items/count").
       * If not specified, uses the main endpoint with countParam. */
@@ -162,6 +164,55 @@ final case class CountConfig(
     paramValue: String = "true",
     /** JSON pointer to extract count from response (e.g., "/total_count"). */
     responsePath: String
+)
+
+/** Aggregation function type for pushdown. */
+sealed trait AggregationFunction extends Serializable
+object AggregationFunction {
+  case object Count extends AggregationFunction
+  case object Sum extends AggregationFunction
+  case object Avg extends AggregationFunction
+  case object Min extends AggregationFunction
+  case object Max extends AggregationFunction
+  /** Custom aggregation - matched by name. */
+  final case class Custom(name: String) extends AggregationFunction
+}
+
+/** Configuration for a single aggregation pushdown.
+  *
+  * Allows pushing aggregations to API endpoints instead of computing locally.
+  * Supports standard SQL aggregates (SUM, AVG, etc.) and custom API-specific functions.
+  *
+  * Example config:
+  * {{{
+  * aggregations {
+  *   total_amount {
+  *     function = "sum"
+  *     column = "amount"
+  *     endpoint = "/orders/stats"
+  *     response-path = "/total"
+  *   }
+  *   amount_p95 {
+  *     function = "custom"
+  *     name = "PERCENTILE"
+  *     endpoint = "/orders/percentiles"
+  *     params { p = "95" }
+  *     response-path = "/value"
+  *   }
+  * }
+  * }}}
+  */
+final case class AggregationConfig(
+    /** Aggregation function type (sum, avg, min, max, count, custom). */
+    function: AggregationFunction,
+    /** Column to aggregate (required for sum, avg, min, max). */
+    column: Option[String] = None,
+    /** Endpoint to call for this aggregation. */
+    endpoint: String,
+    /** JSON pointer to extract result from response (e.g., "/total"). */
+    responsePath: String,
+    /** Additional query parameters to send with the request. */
+    params: Map[String, String] = Map.empty
 )
 
 final case class TableConfig(
@@ -185,8 +236,11 @@ final case class TableConfig(
     /** Field in child records that references the parent (batch join strategy).
       * Defaults to parentKey if not specified. */
     childKeyField: Option[String] = None,
-    /** Configuration for COUNT(*) aggregation pushdown. */
-    count: Option[CountConfig] = None
+    /** Configuration for COUNT(*) aggregation pushdown.
+      * @deprecated Use aggregations with function="count" instead. */
+    count: Option[CountConfig] = None,
+    /** Configurable aggregation pushdown. Maps aggregation name to config. */
+    aggregations: Map[String, AggregationConfig] = Map.empty
 )
 
 final case class CacheConfig(

--- a/src/main/scala/com/apilytics/spark/AggregationInputPartition.scala
+++ b/src/main/scala/com/apilytics/spark/AggregationInputPartition.scala
@@ -1,0 +1,21 @@
+package com.apilytics.spark
+
+import com.apilytics.core.config.{AggregationConfig, SourceConfig}
+import org.apache.spark.sql.connector.read.InputPartition
+
+/** Input partition for aggregation pushdown.
+  *
+  * Instead of fetching all data and aggregating locally, this partition
+  * calls configured aggregation endpoints to get results directly from the API.
+  *
+  * Supports multiple aggregations in a single query (e.g., SELECT SUM(a), AVG(b)).
+  */
+case class AggregationInputPartition(
+    /** Resolved aggregation configs for each pushed aggregate. */
+    aggregationConfigs: List[AggregationConfig],
+    sourceConfig: SourceConfig,
+    baseUrl: String,
+    pushedParams: Map[String, String],
+    /** Effective rate limit for this partition. */
+    effectiveRateLimit: Option[Int] = None
+) extends InputPartition

--- a/src/main/scala/com/apilytics/spark/AggregationPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/AggregationPartitionReader.scala
@@ -10,6 +10,7 @@ import io.circe.Json
 import io.circe.pointer.Pointer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
+import org.apache.spark.unsafe.types.UTF8String
 import org.http4s.Uri
 
 /** Partition reader for aggregation pushdown.
@@ -87,13 +88,15 @@ class AggregationPartitionReader(partition: AggregationInputPartition) extends P
     }
   }
 
-  /** Convert JSON value to Scala type for InternalRow. */
+  /** Convert JSON value to Spark InternalRow types.
+    * Strings must be UTF8String for Spark compatibility.
+    */
   private def jsonToScala(json: Json): Any = {
     json.fold(
       jsonNull = null,
       jsonBoolean = identity,
       jsonNumber = n => n.toLong.getOrElse(n.toDouble),
-      jsonString = identity,
+      jsonString = s => UTF8String.fromString(s),
       jsonArray = arr => arr.map(jsonToScala).toArray,
       jsonObject = obj => obj.toMap.map { case (k, v) => k -> jsonToScala(v) }
     )

--- a/src/main/scala/com/apilytics/spark/AggregationPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/AggregationPartitionReader.scala
@@ -1,0 +1,101 @@
+package com.apilytics.spark
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits._
+import com.apilytics.core.config.AggregationConfig
+import com.apilytics.core.http.Client
+import com.apilytics.core.http.Client.RestClient
+import io.circe.Json
+import io.circe.pointer.Pointer
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.PartitionReader
+import org.http4s.Uri
+
+/** Partition reader for aggregation pushdown.
+  *
+  * Makes HTTP requests to aggregation endpoints and returns a single row
+  * with all aggregation results.
+  *
+  * For multiple aggregations, each is fetched from its configured endpoint.
+  * Results are returned as a single row with values in config order.
+  */
+class AggregationPartitionReader(partition: AggregationInputPartition) extends PartitionReader[InternalRow] {
+
+  private val results: Array[Any] = fetchAggregations()
+  private var returned = false
+
+  override def next(): Boolean = {
+    if (!returned) {
+      returned = true
+      true
+    } else {
+      false
+    }
+  }
+
+  override def get(): InternalRow = InternalRow.fromSeq(results.toSeq)
+
+  override def close(): Unit = ()
+
+  /** Fetch all aggregation results. */
+  private def fetchAggregations(): Array[Any] = {
+    // Use effective rate limit
+    val httpConfig = partition.effectiveRateLimit match {
+      case Some(_) => partition.sourceConfig.http.copy(rateLimit = partition.effectiveRateLimit)
+      case None    => partition.sourceConfig.http
+    }
+
+    val program: IO[Array[Any]] = Client
+      .resource(httpConfig, partition.sourceConfig.auth)
+      .use { client =>
+        // Fetch each aggregation
+        // TODO: Optimize by grouping configs with same endpoint
+        partition.aggregationConfigs.traverse { config =>
+          fetchSingleAggregation(client, config)
+        }.map(_.toArray)
+      }
+
+    program.unsafeRunSync()
+  }
+
+  /** Fetch a single aggregation result. */
+  private def fetchSingleAggregation(client: RestClient, config: AggregationConfig): IO[Any] = {
+    val uri = Uri.unsafeFromString(partition.baseUrl + config.endpoint)
+
+    // Merge pushed params with config params
+    val params = partition.pushedParams ++ config.params
+
+    client.get(uri, params).map { response =>
+      extractValue(response.json, config.responsePath)
+    }
+  }
+
+  /** Extract value from JSON using JSON pointer. */
+  private def extractValue(json: Json, responsePath: String): Any = {
+    val pointer = Pointer.parse(responsePath).getOrElse(
+      throw new IllegalArgumentException(s"Invalid JSON pointer: $responsePath")
+    )
+
+    pointer.get(json) match {
+      case Right(valueJson) =>
+        jsonToScala(valueJson)
+      case Left(_) =>
+        throw new RuntimeException(
+          s"Value not found at '$responsePath' in response: $json"
+        )
+    }
+  }
+
+  /** Convert JSON value to Scala type for InternalRow. */
+  private def jsonToScala(json: Json): Any = {
+    json.fold(
+      jsonNull = null,
+      jsonBoolean = identity,
+      jsonNumber = n => n.toLong.getOrElse(n.toDouble),
+      jsonString = identity,
+      jsonArray = arr => arr.map(jsonToScala).toArray,
+      jsonObject = obj => obj.toMap.map { case (k, v) => k -> jsonToScala(v) }
+    )
+  }
+}

--- a/src/main/scala/com/apilytics/spark/RESTPartitionReaderFactory.scala
+++ b/src/main/scala/com/apilytics/spark/RESTPartitionReaderFactory.scala
@@ -7,10 +7,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 class RESTPartitionReaderFactory extends PartitionReaderFactory {
 
   override def supportColumnarReads(partition: InputPartition): Boolean = {
-    // CountInputPartition returns a single row, use row-based reader
+    // Aggregation partitions return a single row, use row-based reader
     partition match {
-      case _: CountInputPartition => false
-      case _                      => true
+      case _: CountInputPartition       => false
+      case _: AggregationInputPartition => false
+      case _                            => true
     }
   }
 
@@ -25,8 +26,9 @@ class RESTPartitionReaderFactory extends PartitionReaderFactory {
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     partition match {
-      case p: RESTInputPartition   => new RESTPartitionReader(p)
-      case p: CountInputPartition  => new CountPartitionReader(p)
+      case p: RESTInputPartition        => new RESTPartitionReader(p)
+      case p: CountInputPartition       => new CountPartitionReader(p)
+      case p: AggregationInputPartition => new AggregationPartitionReader(p)
       case other => throw new IllegalArgumentException(
         s"Unknown partition type: ${other.getClass.getSimpleName}"
       )

--- a/src/main/scala/com/apilytics/spark/RESTScan.scala
+++ b/src/main/scala/com/apilytics/spark/RESTScan.scala
@@ -1,6 +1,6 @@
 package com.apilytics.spark
 
-import com.apilytics.core.config.PartitionConfig
+import com.apilytics.core.config.{AggregationConfig, PartitionConfig}
 import org.apache.arrow.vector.types.pojo.{Schema => ArrowSchema}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
@@ -16,7 +16,8 @@ class RESTScan(
     prunedSchema: Option[StructType],
     pushedParams: Map[String, String],
     pushedLimit: Option[Int],
-    pushedAggregation: Option[Aggregation] = None
+    pushedAggregation: Option[Aggregation] = None,
+    resolvedAggConfigs: List[AggregationConfig] = Nil
 ) extends Scan with Batch with SupportsReportStatistics with Logging {
 
   // If pruned, return the pruned schema; otherwise return full schema
@@ -25,23 +26,44 @@ class RESTScan(
   override def toBatch(): Batch = this
 
   override def planInputPartitions(): Array[InputPartition] = {
-    // If aggregation is pushed, return a single count partition
+    // If aggregation is pushed, return an aggregation partition
     pushedAggregation match {
-      case Some(_) =>
-        planCountPartition()
+      case Some(agg) =>
+        planAggregationPartition(agg)
       case None =>
         planDataPartitions()
     }
   }
 
-  /** Plan a single partition for COUNT(*) aggregation. */
-  private def planCountPartition(): Array[InputPartition] = {
+  /** Plan a single partition for aggregation pushdown. */
+  private def planAggregationPartition(agg: Aggregation): Array[InputPartition] = {
+    if (resolvedAggConfigs.isEmpty) {
+      // Fallback to legacy count config for backwards compatibility
+      planLegacyCountPartition()
+    } else {
+      logInfo(s"Planning aggregation partition for ${resolvedAggConfigs.size} aggregate(s)")
+
+      // Single partition gets full rate limit
+      val effectiveRateLimit = table.sourceConfig.http.rateLimit
+
+      Array(AggregationInputPartition(
+        aggregationConfigs = resolvedAggConfigs,
+        sourceConfig = table.sourceConfig,
+        baseUrl = table.baseUrl,
+        pushedParams = pushedParams,
+        effectiveRateLimit = effectiveRateLimit
+      ))
+    }
+  }
+
+  /** Plan a single partition for legacy COUNT(*) config. */
+  private def planLegacyCountPartition(): Array[InputPartition] = {
     val tableConfig = table.tableConfig
       .getOrElse(throw new IllegalStateException("COUNT(*) pushed but no table config"))
     val countConfig = tableConfig.count
       .getOrElse(throw new IllegalStateException("COUNT(*) pushed but no count config"))
 
-    logInfo("Planning COUNT(*) partition using count endpoint")
+    logInfo("Planning COUNT(*) partition using legacy count endpoint")
 
     // Single partition gets full rate limit
     val effectiveRateLimit = table.sourceConfig.http.rateLimit

--- a/src/main/scala/com/apilytics/spark/RESTScanBuilder.scala
+++ b/src/main/scala/com/apilytics/spark/RESTScanBuilder.scala
@@ -165,14 +165,9 @@ class RESTScanBuilder(table: RESTTable) extends ScanBuilder
     * from the API, so Spark doesn't need to do any additional aggregation.
     */
   override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
-    val groups = aggregation.groupByExpressions()
-    val aggs = aggregation.aggregateExpressions()
-
-    // Complete pushdown only if no GROUP BY and all aggs are matched
-    if (groups.nonEmpty) return false
-
-    val matched = aggs.flatMap(matchAggregateToConfig)
-    matched.length == aggs.length
+    // pushAggregation already validated and stored resolved configs
+    // Complete pushdown if we matched all aggregates (no GROUP BY check needed - already done)
+    resolvedAggConfigs.length == aggregation.aggregateExpressions().length
   }
 
   override def build(): Scan = {

--- a/src/main/scala/com/apilytics/spark/RESTScanBuilder.scala
+++ b/src/main/scala/com/apilytics/spark/RESTScanBuilder.scala
@@ -1,8 +1,9 @@
 package com.apilytics.spark
 
-import com.apilytics.core.config.{CountConfig, FilterConfig}
+import com.apilytics.core.config.{AggregationConfig, AggregationFunction, CountConfig, FilterConfig}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, CountStar}
+import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownLimit, SupportsPushDownRequiredColumns, SupportsPushDownV2Filters}
 import org.apache.spark.sql.types.StructType
 
@@ -16,12 +17,19 @@ class RESTScanBuilder(table: RESTTable) extends ScanBuilder
 
   private var prunedSchema: Option[StructType] = None
   private var pushedAggregation: Option[Aggregation] = None
+  /** Resolved aggregation configs for the pushed aggregation. */
+  private var resolvedAggConfigs: List[AggregationConfig] = Nil
 
   override protected val filterConfigs: List[FilterConfig] =
     table.tableConfig.map(_.filters).getOrElse(Nil)
 
+  /** Legacy count config for backwards compatibility. */
   private val countConfig: Option[CountConfig] =
     table.tableConfig.flatMap(_.count)
+
+  /** New aggregation configs. */
+  private val aggregationConfigs: Map[String, AggregationConfig] =
+    table.tableConfig.map(_.aggregations).getOrElse(Map.empty)
 
   override def pruneColumns(requiredSchema: StructType): Unit = {
     prunedSchema = Some(requiredSchema)
@@ -29,52 +37,142 @@ class RESTScanBuilder(table: RESTTable) extends ScanBuilder
 
   /** Push aggregation to the API if supported.
     *
-    * We only support COUNT(*) when a count config is provided.
-    * The API must have either a dedicated count endpoint or a count query param.
+    * Supports:
+    * - COUNT(*) via legacy count config or new aggregations
+    * - SUM, AVG, MIN, MAX when configured in aggregations
+    * - Custom aggregations matched by name
     */
   override def pushAggregation(aggregation: Aggregation): Boolean = {
-    // Only support if count config is present
-    if (countConfig.isEmpty) {
-      logDebug("Aggregation pushdown rejected: no count config")
-      return false
-    }
-
-    // Only support COUNT(*) without GROUP BY
     val aggs = aggregation.aggregateExpressions()
     val groups = aggregation.groupByExpressions()
 
+    // GROUP BY not supported
     if (groups.nonEmpty) {
       logDebug(s"Aggregation pushdown rejected: GROUP BY not supported (${groups.length} grouping columns)")
       return false
     }
 
-    if (aggs.length != 1) {
-      logDebug(s"Aggregation pushdown rejected: only single COUNT(*) supported (got ${aggs.length} aggregates)")
+    // Try to match all aggregate expressions to configs
+    val matched = aggs.flatMap(matchAggregateToConfig)
+
+    if (matched.length != aggs.length) {
+      logDebug(s"Aggregation pushdown rejected: could only match ${matched.length} of ${aggs.length} aggregates")
       return false
     }
 
-    aggs(0) match {
+    // All matched - accept the pushdown
+    val descriptions = aggs.map(describeAggregate).mkString(", ")
+    logInfo(s"Aggregations pushed to API: $descriptions")
+    pushedAggregation = Some(aggregation)
+    resolvedAggConfigs = matched.toList
+    true
+  }
+
+  /** Match a Spark aggregate expression to an AggregationConfig. */
+  private def matchAggregateToConfig(agg: AggregateFunc): Option[AggregationConfig] = {
+    agg match {
       case _: CountStar =>
-        logInfo("Aggregation pushed to API: COUNT(*)")
-        pushedAggregation = Some(aggregation)
-        true
-      case other =>
-        logDebug(s"Aggregation pushdown rejected: unsupported aggregate function ${other.getClass.getSimpleName}")
-        false
+        // Try new config first, then legacy
+        findAggConfig(AggregationFunction.Count, None)
+          .orElse(countConfig.map(legacyCountToAggConfig))
+
+      case c: Count =>
+        val col = extractColumnName(c.column())
+        findAggConfig(AggregationFunction.Count, col)
+
+      case s: Sum =>
+        val col = extractColumnName(s.column())
+        findAggConfig(AggregationFunction.Sum, col)
+
+      case a: Avg =>
+        val col = extractColumnName(a.column())
+        findAggConfig(AggregationFunction.Avg, col)
+
+      case m: Min =>
+        val col = extractColumnName(m.column())
+        findAggConfig(AggregationFunction.Min, col)
+
+      case m: Max =>
+        val col = extractColumnName(m.column())
+        findAggConfig(AggregationFunction.Max, col)
+
+      case g: GeneralAggregateFunc =>
+        // Custom aggregation - match by name
+        findCustomAggConfig(g.name())
+
+      case _ =>
+        None
+    }
+  }
+
+  /** Find an aggregation config matching function and optional column. */
+  private def findAggConfig(
+      function: AggregationFunction,
+      column: Option[String]
+  ): Option[AggregationConfig] = {
+    aggregationConfigs.values.find { config =>
+      config.function == function && (column.isEmpty || config.column == column)
+    }
+  }
+
+  /** Find a custom aggregation config by name. */
+  private def findCustomAggConfig(name: String): Option[AggregationConfig] = {
+    aggregationConfigs.values.find {
+      case AggregationConfig(AggregationFunction.Custom(n), _, _, _, _) =>
+        n.equalsIgnoreCase(name)
+      case _ => false
+    }
+  }
+
+  /** Convert legacy CountConfig to AggregationConfig. */
+  private def legacyCountToAggConfig(cc: CountConfig): AggregationConfig = {
+    AggregationConfig(
+      function = AggregationFunction.Count,
+      column = None,
+      endpoint = cc.endpoint.getOrElse(table.tableConfig.map(_.endpoint).getOrElse("")),
+      responsePath = cc.responsePath,
+      params = cc.param.map(p => Map(p -> cc.paramValue)).getOrElse(Map.empty)
+    )
+  }
+
+  /** Extract column name from Spark expression. */
+  private def extractColumnName(expr: org.apache.spark.sql.connector.expressions.Expression): Option[String] = {
+    expr match {
+      case ref: NamedReference =>
+        val names = ref.fieldNames()
+        if (names.nonEmpty) Some(names.mkString(".")) else None
+      case _ => None
+    }
+  }
+
+  /** Describe an aggregate for logging. */
+  private def describeAggregate(agg: AggregateFunc): String = {
+    agg match {
+      case _: CountStar => "COUNT(*)"
+      case c: Count => s"COUNT(${extractColumnName(c.column()).getOrElse("?")})"
+      case s: Sum => s"SUM(${extractColumnName(s.column()).getOrElse("?")})"
+      case a: Avg => s"AVG(${extractColumnName(a.column()).getOrElse("?")})"
+      case m: Min => s"MIN(${extractColumnName(m.column()).getOrElse("?")})"
+      case m: Max => s"MAX(${extractColumnName(m.column()).getOrElse("?")})"
+      case g: GeneralAggregateFunc => s"${g.name()}(...)"
+      case other => other.getClass.getSimpleName
     }
   }
 
   /** Return true if we can fully compute the aggregation without Spark doing any post-aggregation.
     *
-    * For COUNT(*) without GROUP BY, we return the exact count from the API, so Spark
-    * doesn't need to do any additional aggregation.
+    * For aggregations without GROUP BY where all functions are pushed, we return exact values
+    * from the API, so Spark doesn't need to do any additional aggregation.
     */
   override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
-    // Complete pushdown only for COUNT(*) without GROUP BY
     val groups = aggregation.groupByExpressions()
     val aggs = aggregation.aggregateExpressions()
 
-    groups.isEmpty && aggs.length == 1 && aggs(0).isInstanceOf[CountStar] && countConfig.isDefined
+    // Complete pushdown only if no GROUP BY and all aggs are matched
+    if (groups.nonEmpty) return false
+
+    val matched = aggs.flatMap(matchAggregateToConfig)
+    matched.length == aggs.length
   }
 
   override def build(): Scan = {
@@ -82,6 +180,14 @@ class RESTScanBuilder(table: RESTTable) extends ScanBuilder
       case Some(required) => ArrowSchemaConverter.pruneSchema(table.arrowSchema, required)
       case None           => table.arrowSchema
     }
-    new RESTScan(table, finalArrowSchema, prunedSchema, pushedParams, pushedLimit, pushedAggregation)
+    new RESTScan(
+      table,
+      finalArrowSchema,
+      prunedSchema,
+      pushedParams,
+      pushedLimit,
+      pushedAggregation,
+      resolvedAggConfigs
+    )
   }
 }

--- a/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
+++ b/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
@@ -205,4 +205,162 @@ class LoaderSuite extends FunSuite {
     assertEquals(result.http.responseCache.ttl.toMinutes, 10L)
     assertEquals(result.http.responseCache.maxEntries, 500)
   }
+
+  test("aggregations config with standard functions") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |tables {
+        |  orders {
+        |    endpoint = "/orders"
+        |    aggregations {
+        |      total_amount {
+        |        function = sum
+        |        column = "amount"
+        |        endpoint = "/orders/stats"
+        |        response-path = "/total"
+        |      }
+        |      avg_amount {
+        |        function = avg
+        |        column = "amount"
+        |        endpoint = "/orders/stats"
+        |        response-path = "/average"
+        |      }
+        |      min_price {
+        |        function = min
+        |        column = "price"
+        |        endpoint = "/orders/stats"
+        |        response-path = "/min_price"
+        |      }
+        |      max_price {
+        |        function = max
+        |        column = "price"
+        |        endpoint = "/orders/stats"
+        |        response-path = "/max_price"
+        |      }
+        |      order_count {
+        |        function = count
+        |        endpoint = "/orders/count"
+        |        response-path = "/count"
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    val orders = result.tables("orders")
+    assertEquals(orders.aggregations.size, 5)
+
+    val sumAgg = orders.aggregations("total_amount")
+    assertEquals(sumAgg.function, AggregationFunction.Sum)
+    assertEquals(sumAgg.column, Some("amount"))
+    assertEquals(sumAgg.endpoint, "/orders/stats")
+    assertEquals(sumAgg.responsePath, "/total")
+
+    val avgAgg = orders.aggregations("avg_amount")
+    assertEquals(avgAgg.function, AggregationFunction.Avg)
+
+    val minAgg = orders.aggregations("min_price")
+    assertEquals(minAgg.function, AggregationFunction.Min)
+
+    val maxAgg = orders.aggregations("max_price")
+    assertEquals(maxAgg.function, AggregationFunction.Max)
+
+    val countAgg = orders.aggregations("order_count")
+    assertEquals(countAgg.function, AggregationFunction.Count)
+    assertEquals(countAgg.column, None)
+  }
+
+  test("aggregations config with custom function") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |tables {
+        |  orders {
+        |    endpoint = "/orders"
+        |    aggregations {
+        |      amount_p95 {
+        |        function = custom
+        |        name = "PERCENTILE"
+        |        endpoint = "/orders/percentiles"
+        |        response-path = "/p95"
+        |        params {
+        |          percentile = "95"
+        |          column = "amount"
+        |        }
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    val orders = result.tables("orders")
+    val pctAgg = orders.aggregations("amount_p95")
+
+    pctAgg.function match {
+      case AggregationFunction.Custom(name) =>
+        assertEquals(name, "PERCENTILE")
+      case other =>
+        fail(s"Expected Custom function, got $other")
+    }
+    assertEquals(pctAgg.params, Map("percentile" -> "95", "column" -> "amount"))
+  }
+
+  test("aggregation with custom function requires name") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |tables {
+        |  orders {
+        |    endpoint = "/orders"
+        |    aggregations {
+        |      custom_agg {
+        |        function = custom
+        |        endpoint = "/orders/custom"
+        |        response-path = "/result"
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+
+    val ex = intercept[IllegalArgumentException] {
+      Loader.load(config)
+    }
+    assert(ex.getMessage.contains("missing 'name'"))
+  }
+
+  test("sum/avg/min/max aggregation requires column") {
+    val functions = List("sum", "avg", "min", "max")
+
+    functions.foreach { fn =>
+      val config = ConfigFactory.parseString(
+        s"""
+           |openapi = "spec.json"
+           |auth { type = bearer, token = "t" }
+           |tables {
+           |  orders {
+           |    endpoint = "/orders"
+           |    aggregations {
+           |      test_agg {
+           |        function = $fn
+           |        endpoint = "/orders/stats"
+           |        response-path = "/value"
+           |      }
+           |    }
+           |  }
+           |}
+           |""".stripMargin)
+
+      val ex = intercept[IllegalArgumentException] {
+        Loader.load(config)
+      }
+      assert(ex.getMessage.contains("requires 'column'"), s"$fn should require column")
+    }
+  }
 }

--- a/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
@@ -1242,4 +1242,274 @@ class WireMockSuite extends FunSuite {
     server.verify(1, getRequestedFor(urlPathEqualTo("/items/count"))
       .withQueryParam("status", equalTo("active")))
   }
+
+  // ============== AGGREGATION PUSHDOWN TESTS ===============
+
+  test("aggregation pushdown fetches SUM from configured endpoint") {
+    server.stubFor(
+      get(urlPathEqualTo("/orders/stats"))
+        .willReturn(okJson("""{"total": 12500}"""))
+    )
+
+    val aggConfig = AggregationConfig(
+      function = AggregationFunction.Sum,
+      column = Some("amount"),
+      endpoint = "/orders/stats",
+      responsePath = "/total"
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = AggregationInputPartition(
+      aggregationConfigs = List(aggConfig),
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      pushedParams = Map.empty
+    )
+
+    val reader = new AggregationPartitionReader(partition)
+
+    // Should have exactly one row
+    assert(reader.next())
+    val row = reader.get()
+    assertEquals(row.getLong(0), 12500L)
+
+    // No more rows
+    assert(!reader.next())
+    reader.close()
+
+    // Verify aggregation endpoint was called
+    server.verify(1, getRequestedFor(urlPathEqualTo("/orders/stats")))
+  }
+
+  test("aggregation pushdown fetches multiple aggregates") {
+    // Different endpoints for different aggregates
+    server.stubFor(
+      get(urlPathEqualTo("/orders/stats"))
+        .willReturn(okJson("""{"total": 10000, "average": 250.5}"""))
+    )
+    server.stubFor(
+      get(urlPathEqualTo("/orders/count"))
+        .willReturn(okJson("""{"count": 40}"""))
+    )
+
+    val sumConfig = AggregationConfig(
+      function = AggregationFunction.Sum,
+      column = Some("amount"),
+      endpoint = "/orders/stats",
+      responsePath = "/total"
+    )
+    val avgConfig = AggregationConfig(
+      function = AggregationFunction.Avg,
+      column = Some("amount"),
+      endpoint = "/orders/stats",
+      responsePath = "/average"
+    )
+    val countConfig = AggregationConfig(
+      function = AggregationFunction.Count,
+      column = None,
+      endpoint = "/orders/count",
+      responsePath = "/count"
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = AggregationInputPartition(
+      aggregationConfigs = List(sumConfig, avgConfig, countConfig),
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      pushedParams = Map.empty
+    )
+
+    val reader = new AggregationPartitionReader(partition)
+
+    assert(reader.next())
+    val row = reader.get()
+    assertEquals(row.getLong(0), 10000L)       // SUM
+    assertEquals(row.getDouble(1), 250.5, 0.001)  // AVG
+    assertEquals(row.getLong(2), 40L)          // COUNT
+
+    assert(!reader.next())
+    reader.close()
+
+    // Verify both endpoints were called
+    // Note: Currently each agg makes its own request (issue #131 tracks deduplication)
+    server.verify(2, getRequestedFor(urlPathEqualTo("/orders/stats")))
+    server.verify(1, getRequestedFor(urlPathEqualTo("/orders/count")))
+  }
+
+  test("aggregation pushdown includes pushed filter params") {
+    server.stubFor(
+      get(urlPathEqualTo("/orders/stats"))
+        .withQueryParam("status", equalTo("completed"))
+        .willReturn(okJson("""{"sum": 5000}"""))
+    )
+
+    val aggConfig = AggregationConfig(
+      function = AggregationFunction.Sum,
+      column = Some("amount"),
+      endpoint = "/orders/stats",
+      responsePath = "/sum"
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = AggregationInputPartition(
+      aggregationConfigs = List(aggConfig),
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      pushedParams = Map("status" -> "completed")
+    )
+
+    val reader = new AggregationPartitionReader(partition)
+
+    assert(reader.next())
+    assertEquals(reader.get().getLong(0), 5000L)
+    reader.close()
+
+    // Verify filter was passed to aggregation endpoint
+    server.verify(1, getRequestedFor(urlPathEqualTo("/orders/stats"))
+      .withQueryParam("status", equalTo("completed")))
+  }
+
+  test("aggregation pushdown merges config params with pushed params") {
+    server.stubFor(
+      get(urlPathEqualTo("/orders/percentiles"))
+        .withQueryParam("percentile", equalTo("95"))
+        .withQueryParam("column", equalTo("amount"))
+        .withQueryParam("region", equalTo("us-west"))
+        .willReturn(okJson("""{"p95": 999.99}"""))
+    )
+
+    val aggConfig = AggregationConfig(
+      function = AggregationFunction.Custom("PERCENTILE"),
+      column = None,
+      endpoint = "/orders/percentiles",
+      responsePath = "/p95",
+      params = Map("percentile" -> "95", "column" -> "amount")
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = AggregationInputPartition(
+      aggregationConfigs = List(aggConfig),
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      pushedParams = Map("region" -> "us-west")
+    )
+
+    val reader = new AggregationPartitionReader(partition)
+
+    assert(reader.next())
+    assertEquals(reader.get().getDouble(0), 999.99, 0.001)
+    reader.close()
+
+    // Verify both config params and pushed params were sent
+    server.verify(1, getRequestedFor(urlPathEqualTo("/orders/percentiles"))
+      .withQueryParam("percentile", equalTo("95"))
+      .withQueryParam("column", equalTo("amount"))
+      .withQueryParam("region", equalTo("us-west")))
+  }
+
+  test("aggregation pushdown handles string values with UTF8String") {
+    server.stubFor(
+      get(urlPathEqualTo("/orders/mode"))
+        .willReturn(okJson("""{"mode_value": "premium"}"""))
+    )
+
+    val aggConfig = AggregationConfig(
+      function = AggregationFunction.Custom("MODE"),
+      column = Some("tier"),
+      endpoint = "/orders/mode",
+      responsePath = "/mode_value"
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = AggregationInputPartition(
+      aggregationConfigs = List(aggConfig),
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      pushedParams = Map.empty
+    )
+
+    val reader = new AggregationPartitionReader(partition)
+
+    assert(reader.next())
+    val row = reader.get()
+    // The value should be UTF8String, not regular String
+    val value = row.getUTF8String(0)
+    assertEquals(value.toString, "premium")
+
+    reader.close()
+  }
+
+  test("aggregation pushdown handles MIN and MAX") {
+    server.stubFor(
+      get(urlPathEqualTo("/orders/stats"))
+        .willReturn(okJson("""{"min_price": 10, "max_price": 500}"""))
+    )
+
+    val minConfig = AggregationConfig(
+      function = AggregationFunction.Min,
+      column = Some("price"),
+      endpoint = "/orders/stats",
+      responsePath = "/min_price"
+    )
+    val maxConfig = AggregationConfig(
+      function = AggregationFunction.Max,
+      column = Some("price"),
+      endpoint = "/orders/stats",
+      responsePath = "/max_price"
+    )
+
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = noAuth,
+      http = defaultHttp,
+      baseUrl = Some(s"http://localhost:${server.port()}")
+    )
+
+    val partition = AggregationInputPartition(
+      aggregationConfigs = List(minConfig, maxConfig),
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      pushedParams = Map.empty
+    )
+
+    val reader = new AggregationPartitionReader(partition)
+
+    assert(reader.next())
+    val row = reader.get()
+    assertEquals(row.getLong(0), 10L)   // MIN
+    assertEquals(row.getLong(1), 500L)  // MAX
+
+    assert(!reader.next())
+    reader.close()
+  }
 }


### PR DESCRIPTION
Closes #126

## Summary
- Implement fully configurable aggregation pushdown to API endpoints
- Support standard aggregations: SUM, AVG, MIN, MAX, COUNT
- Support custom aggregations for API-specific functions (percentiles, quartiles, etc.)
- Backwards compatible with existing `count` config

## Config Example
```hocon
tables {
  orders {
    endpoint = "/orders"
    aggregations {
      total_amount {
        function = sum
        column = "amount"
        endpoint = "/orders/stats"
        response-path = "/total"
      }
      amount_p95 {
        function = custom
        name = "PERCENTILE"
        endpoint = "/orders/percentiles"
        response-path = "/p95"
        params { p = "95" }
      }
    }
  }
}
```

## SQL Usage
```sql
SELECT SUM(amount), AVG(amount) FROM api.default.orders
```

## Implementation
- `AggregationConfig` model with `AggregationFunction` sealed trait
- Config parsing with validation (column required for sum/avg/min/max)
- `RESTScanBuilder` matches Spark aggregate expressions to configs
- `AggregationInputPartition` and `AggregationPartitionReader` for fetching results

## Test plan
- [x] Config loading tests for all aggregation types
- [x] Validation tests (custom requires name, sum/avg/min/max require column)
- [x] All 226 tests pass