### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "io.github.neutrinic"
-ThisBuild / version := "0.4.0"
+ThisBuild / version := "0.5.0"
 ThisBuild / scalaVersion := "2.13.16"
 
 // Publishing settings for Maven Central


### PR DESCRIPTION
Closes #132

## Summary
- Update version in build.sbt from 0.4.0 to 0.5.0 for release

## Test plan
- CI release workflow will use correct version