### PR TITLE
Add PySpark support to Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Turn any REST API with an OpenAPI spec into queryable Apache Spark tables.
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.neutrinic" %% "apilytics" % "0.4.0"
+libraryDependencies += "io.github.neutrinic" %% "apilytics" % "0.5.0"
 ```
 
 ```bash
 # spark-submit
-spark-submit --packages io.github.neutrinic:apilytics_2.13:0.4.0 your-app.jar
+spark-submit --packages io.github.neutrinic:apilytics_2.13:0.5.0 your-app.jar
 
 # spark-shell
-spark-shell --packages io.github.neutrinic:apilytics_2.13:0.4.0
+spark-shell --packages io.github.neutrinic:apilytics_2.13:0.5.0
 ```
 
 Then configure the catalog:
@@ -55,6 +55,18 @@ docker run --rm ghcr.io/neutrinic/apilytics --help
 Bundled configs:
 - `pokeapi.conf` (default) - PokeAPI, no auth
 - `github-public.conf` - GitHub public repos, no auth (60 req/hour limit)
+
+### PySpark
+
+The Docker image includes Python for PySpark:
+
+```bash
+# Interactive PySpark shell
+docker run -it --rm ghcr.io/neutrinic/apilytics:latest pyspark
+
+# Run a Python script
+docker run -it --rm ghcr.io/neutrinic/apilytics:latest spark-submit /opt/apilytics/examples/pyspark/basic.py
+```
 
 ## Development Setup
 

--- a/docker/dist/Dockerfile
+++ b/docker/dist/Dockerfile
@@ -12,15 +12,18 @@ LABEL org.opencontainers.image.description="Query REST APIs with Spark SQL"
 ARG SPARK_VERSION=4.0.0
 ARG JDK_VERSION=21
 
-# Install dependencies
+# Install dependencies (including Python for PySpark)
 RUN microdnf update -y && \
-    microdnf install -y java-${JDK_VERSION}-openjdk-devel tar gzip curl procps && \
-    microdnf clean all
+    microdnf install -y java-${JDK_VERSION}-openjdk-devel tar gzip curl procps python3.11 python3.11-pip && \
+    microdnf clean all && \
+    ln -sf /usr/bin/python3.11 /usr/bin/python3 && \
+    ln -sf /usr/bin/python3.11 /usr/bin/python
 
 # Environment variables
 ENV JAVA_HOME=/usr/lib/jvm/java-${JDK_VERSION}-openjdk
 ENV SPARK_HOME=/opt/spark
-ENV PATH=$PATH:$SPARK_HOME/bin
+ENV PYSPARK_PYTHON=/usr/bin/python3
+ENV PATH=$PATH:$SPARK_HOME/bin:$SPARK_HOME/python
 
 # JVM options for Java 21 compatibility
 ENV SPARK_DAEMON_JAVA_OPTS="--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED"
@@ -37,8 +40,9 @@ RUN mkdir -p ${SPARK_HOME}/logs ${SPARK_HOME}/work
 # Copy Apilytics JAR (built externally and passed as build context)
 COPY apilytics.jar ${SPARK_HOME}/jars/
 
-# Copy bundled configs
+# Copy bundled configs and examples
 COPY configs/ /opt/apilytics/configs/
+COPY examples/ /opt/apilytics/examples/
 
 # Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh

--- a/docker/dist/entrypoint.sh
+++ b/docker/dist/entrypoint.sh
@@ -46,6 +46,14 @@ while [[ $# -gt 0 ]]; do
       echo "  /opt/apilytics/configs/pokeapi.conf       - PokeAPI (default)"
       echo "  /opt/apilytics/configs/github-public.conf - GitHub public repos"
       echo ""
+      echo "PySpark:"
+      echo "  # Run PySpark example"
+      echo "  docker run -it neutrinic/apilytics pyspark"
+      echo "  docker run -it neutrinic/apilytics python3 /opt/apilytics/examples/pyspark/basic.py"
+      echo ""
+      echo "  # Interactive PySpark shell"
+      echo "  docker run -it neutrinic/apilytics pyspark"
+      echo ""
       echo "Example Queries (PokeAPI - default):"
       echo "  -- List types"
       echo "  SELECT name FROM api.default.types;"
@@ -65,6 +73,25 @@ while [[ $# -gt 0 ]]; do
       echo "  -- Filter by date"
       echo "  SELECT count(*) FROM api.default.issues WHERE created_at >= '2026-01-01';"
       exit 0
+      ;;
+    pyspark)
+      # Launch PySpark interactive shell with catalog configured
+      exec pyspark \
+        --conf "spark.sql.catalog.$CATALOG_NAME=com.apilytics.spark.RESTCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.config=$CONFIG_FILE"
+      ;;
+    python3|python)
+      # Run Python script with PySpark
+      shift
+      exec python3 "$@"
+      ;;
+    spark-submit)
+      # Run spark-submit with catalog configured
+      shift
+      exec spark-submit \
+        --conf "spark.sql.catalog.$CATALOG_NAME=com.apilytics.spark.RESTCatalog" \
+        --conf "spark.sql.catalog.$CATALOG_NAME.config=$CONFIG_FILE" \
+        "$@"
       ;;
     *)
       SQL_QUERY="$1"

--- a/docker/dist/examples/pyspark/basic.py
+++ b/docker/dist/examples/pyspark/basic.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Basic PySpark example for Apilytics.
+
+Usage (inside Docker container):
+    python3 /opt/apilytics/examples/pyspark/basic.py
+
+Or with spark-submit:
+    spark-submit /opt/apilytics/examples/pyspark/basic.py
+"""
+
+from pyspark.sql import SparkSession
+
+# Create SparkSession with Apilytics catalog configured
+spark = SparkSession.builder \
+    .appName("Apilytics PySpark Example") \
+    .config("spark.sql.catalog.api", "com.apilytics.spark.RESTCatalog") \
+    .config("spark.sql.catalog.api.config", "/opt/apilytics/configs/pokeapi.conf") \
+    .getOrCreate()
+
+# Query Pokemon API
+print("\n=== Pokemon (first 5) ===")
+df = spark.sql("SELECT name, url FROM api.default.pokemon LIMIT 5")
+df.show(truncate=False)
+
+# Show schema
+print("\n=== Schema ===")
+df.printSchema()
+
+# DataFrame API works too
+print("\n=== Using DataFrame API ===")
+pokemon = spark.table("api.default.pokemon")
+pokemon.select("name").show(5)
+
+spark.stop()

--- a/docker/dist/examples/pyspark/github_issues.py
+++ b/docker/dist/examples/pyspark/github_issues.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+PySpark example querying GitHub Issues API.
+
+Requires GITHUB_TOKEN environment variable.
+
+Usage:
+    GITHUB_TOKEN=ghp_xxx docker run -e GITHUB_TOKEN -it neutrinic/apilytics \
+        python3 /opt/apilytics/examples/pyspark/github_issues.py
+"""
+
+from pyspark.sql import SparkSession
+import os
+
+# Check for token
+if not os.environ.get("GITHUB_TOKEN"):
+    print("Warning: GITHUB_TOKEN not set. Some queries may fail.")
+
+spark = SparkSession.builder \
+    .appName("GitHub Issues Example") \
+    .config("spark.sql.catalog.api", "com.apilytics.spark.RESTCatalog") \
+    .config("spark.sql.catalog.api.config", "/opt/apilytics/configs/github-public.conf") \
+    .getOrCreate()
+
+# Query issues
+print("\n=== Recent Issues ===")
+df = spark.sql("""
+    SELECT number, title, state, created_at
+    FROM api.default.issues
+    LIMIT 10
+""")
+df.show(truncate=40)
+
+# Aggregation example
+print("\n=== Issues by State ===")
+spark.sql("""
+    SELECT state, COUNT(*) as count
+    FROM api.default.issues
+    GROUP BY state
+""").show()
+
+spark.stop()

--- a/examples/pyspark/basic.py
+++ b/examples/pyspark/basic.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Basic PySpark example for Apilytics.
+
+Usage (inside Docker container):
+    python3 /opt/apilytics/examples/pyspark/basic.py
+
+Or with spark-submit:
+    spark-submit /opt/apilytics/examples/pyspark/basic.py
+"""
+
+from pyspark.sql import SparkSession
+
+# Create SparkSession with Apilytics catalog configured
+spark = SparkSession.builder \
+    .appName("Apilytics PySpark Example") \
+    .config("spark.sql.catalog.api", "com.apilytics.spark.RESTCatalog") \
+    .config("spark.sql.catalog.api.config", "/opt/apilytics/configs/pokeapi.conf") \
+    .getOrCreate()
+
+# Query Pokemon API
+print("\n=== Pokemon (first 5) ===")
+df = spark.sql("SELECT name, url FROM api.default.pokemon LIMIT 5")
+df.show(truncate=False)
+
+# Show schema
+print("\n=== Schema ===")
+df.printSchema()
+
+# DataFrame API works too
+print("\n=== Using DataFrame API ===")
+pokemon = spark.table("api.default.pokemon")
+pokemon.select("name").show(5)
+
+spark.stop()

--- a/examples/pyspark/github_issues.py
+++ b/examples/pyspark/github_issues.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+PySpark example querying GitHub Issues API.
+
+Requires GITHUB_TOKEN environment variable.
+
+Usage:
+    GITHUB_TOKEN=ghp_xxx docker run -e GITHUB_TOKEN -it neutrinic/apilytics \
+        python3 /opt/apilytics/examples/pyspark/github_issues.py
+"""
+
+from pyspark.sql import SparkSession
+import os
+
+# Check for token
+if not os.environ.get("GITHUB_TOKEN"):
+    print("Warning: GITHUB_TOKEN not set. Some queries may fail.")
+
+spark = SparkSession.builder \
+    .appName("GitHub Issues Example") \
+    .config("spark.sql.catalog.api", "com.apilytics.spark.RESTCatalog") \
+    .config("spark.sql.catalog.api.config", "/opt/apilytics/configs/github-public.conf") \
+    .getOrCreate()
+
+# Query issues
+print("\n=== Recent Issues ===")
+df = spark.sql("""
+    SELECT number, title, state, created_at
+    FROM api.default.issues
+    LIMIT 10
+""")
+df.show(truncate=40)
+
+# Aggregation example
+print("\n=== Issues by State ===")
+spark.sql("""
+    SELECT state, COUNT(*) as count
+    FROM api.default.issues
+    GROUP BY state
+""").show()
+
+spark.stop()


### PR DESCRIPTION
Closes #127

## Summary
- Add Python 3.11 to Docker image for PySpark support
- Add PySpark examples (`basic.py`, `github_issues.py`)
- Update entrypoint to support `pyspark`, `python3`, `spark-submit` commands

## Usage
```bash
# Interactive PySpark shell
docker run -it apilytics:latest pyspark

# Run PySpark example
docker run -it apilytics:latest spark-submit /opt/apilytics/examples/pyspark/basic.py
```

## Test plan
- [x] Tested locally with `spark-submit` running basic.py example
- [x] Verified Pokemon query works via PySpark