### PR TITLE
Add Swagger 2.0 (OpenAPI 2.x) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ SELECT * FROM pokemon.default.pokemon LIMIT 10;
 
 ## Overview
 
-APIlytics is a Spark DataSource V2 catalog plugin that reads OpenAPI 3.x specifications and exposes API endpoints as Spark tables. Filters and limits are pushed down to query parameters, pagination is handled automatically, and responses are converted to Arrow columnar format for efficient processing.
+APIlytics is a Spark DataSource V2 catalog plugin that reads OpenAPI specs (Swagger 2.0, OpenAPI 3.0/3.1) and exposes API endpoints as Spark tables. Filters and limits are pushed down to query parameters, pagination is handled automatically, and responses are converted to Arrow columnar format for efficient processing.
 
 ## Features
 
-- **OpenAPI 3.x** parsing via swagger-parser - GET endpoints with array responses become tables
+- **OpenAPI parsing** - Swagger 2.0, OpenAPI 3.0/3.1 via swagger-parser; GET endpoints with array responses become tables
 - **Pagination** - cursor, offset, and link header strategies with configurable page sizes
 - **Authentication** - bearer token, basic auth, custom headers, OAuth2 client credentials
 - **Filter pushdown** - Spark SQL filters map to API query parameters

--- a/src/main/scala/com/apilytics/core/openapi/Parser.scala
+++ b/src/main/scala/com/apilytics/core/openapi/Parser.scala
@@ -3,6 +3,7 @@ package com.apilytics.core.openapi
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.{Schema => SwaggerSchema}
 import io.swagger.v3.parser.OpenAPIV3Parser
+import io.swagger.v3.parser.converter.SwaggerConverter
 import io.swagger.v3.parser.core.models.ParseOptions
 
 import scala.jdk.CollectionConverters._
@@ -39,31 +40,55 @@ final case class QueryParam(
 ) extends Serializable
 
 object Parser {
+  import io.swagger.v3.parser.core.models.SwaggerParseResult
 
   def parse(specLocation: String): ParsedSpec = {
-    val opts = new ParseOptions()
-    opts.setResolve(true)
-    opts.setResolveFully(true)
-
-    val result = new OpenAPIV3Parser().readLocation(specLocation, null, opts)
-    if (result.getOpenAPI == null) {
-      val messages = Option(result.getMessages).map(_.asScala.mkString(", ")).getOrElse("unknown error")
-      throw new IllegalArgumentException(s"Failed to parse OpenAPI spec: $messages")
-    }
-    extractEndpoints(result.getOpenAPI)
+    val opts = parseOptions()
+    parseWithFallback(
+      () => new OpenAPIV3Parser().readLocation(specLocation, null, opts),
+      () => new SwaggerConverter().readLocation(specLocation, null, opts)
+    )
   }
 
   def parseContent(specJson: String): ParsedSpec = {
+    val opts = parseOptions()
+    parseWithFallback(
+      () => new OpenAPIV3Parser().readContents(specJson, null, opts),
+      () => new SwaggerConverter().readContents(specJson, null, opts)
+    )
+  }
+
+  private def parseOptions(): ParseOptions = {
     val opts = new ParseOptions()
     opts.setResolve(true)
     opts.setResolveFully(true)
+    opts
+  }
 
-    val result = new OpenAPIV3Parser().readContents(specJson, null, opts)
-    if (result.getOpenAPI == null) {
-      val messages = Option(result.getMessages).map(_.asScala.mkString(", ")).getOrElse("unknown error")
-      throw new IllegalArgumentException(s"Failed to parse OpenAPI spec: $messages")
+  private def parseWithFallback(
+      tryOpenApi3: () => SwaggerParseResult,
+      trySwagger2: () => SwaggerParseResult
+  ): ParsedSpec = {
+    val result3x = tryOpenApi3()
+    if (result3x.getOpenAPI != null) {
+      return extractEndpoints(result3x.getOpenAPI)
     }
-    extractEndpoints(result.getOpenAPI)
+
+    val result2 = trySwagger2()
+    if (result2.getOpenAPI != null) {
+      return extractEndpoints(result2.getOpenAPI)
+    }
+
+    // Collect error messages from both parsers
+    val msgs3x = Option(result3x.getMessages).map(_.asScala.toList).getOrElse(Nil)
+    val msgs2 = Option(result2.getMessages).map(_.asScala.toList).getOrElse(Nil)
+    val combined = (msgs3x, msgs2) match {
+      case (Nil, Nil) => "unknown error"
+      case (m3, Nil)  => s"OpenAPI 3.x: ${m3.mkString(", ")}"
+      case (Nil, m2)  => s"Swagger 2.0: ${m2.mkString(", ")}"
+      case (m3, m2)   => s"OpenAPI 3.x: ${m3.mkString(", ")}; Swagger 2.0: ${m2.mkString(", ")}"
+    }
+    throw new IllegalArgumentException(s"Failed to parse spec: $combined")
   }
 
   private def extractEndpoints(api: OpenAPI): ParsedSpec = {

--- a/src/test/scala/com/apilytics/core/openapi/ParserSuite.scala
+++ b/src/test/scala/com/apilytics/core/openapi/ParserSuite.scala
@@ -597,4 +597,211 @@ class ParserSuite extends FunSuite {
     assert(props("id").isInstanceOf[OpenAPISchema.IntegerType])
     assert(props("name").isInstanceOf[OpenAPISchema.StringType])
   }
+
+  // ==========================================================================
+  // Swagger 2.0 compatibility tests (#138)
+  // ==========================================================================
+
+  test("Swagger 2.0: basic spec parses correctly") {
+    // Swagger 2.0 uses "swagger": "2.0" instead of "openapi"
+    // and has different response structure (no "content" wrapper)
+    val spec =
+      """{
+        |  "swagger": "2.0",
+        |  "info": { "title": "Test Swagger 2.0", "version": "1.0" },
+        |  "host": "api.example.com",
+        |  "basePath": "/v1",
+        |  "schemes": ["https"],
+        |  "paths": {
+        |    "/users": {
+        |      "get": {
+        |        "produces": ["application/json"],
+        |        "responses": {
+        |          "200": {
+        |            "description": "OK",
+        |            "schema": {
+        |              "type": "object",
+        |              "properties": {
+        |                "id": { "type": "integer" },
+        |                "name": { "type": "string" }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val result = Parser.parseContent(spec)
+    assertEquals(result.endpoints.size, 1)
+    assertEquals(result.endpoints.head.path, "/users")
+    val props = result.endpoints.head.responseSchema.properties
+    assert(props("id").isInstanceOf[OpenAPISchema.IntegerType])
+    assert(props("name").isInstanceOf[OpenAPISchema.StringType])
+  }
+
+  test("Swagger 2.0: array response parses") {
+    val spec =
+      """{
+        |  "swagger": "2.0",
+        |  "info": { "title": "Test", "version": "1.0" },
+        |  "paths": {
+        |    "/items": {
+        |      "get": {
+        |        "produces": ["application/json"],
+        |        "responses": {
+        |          "200": {
+        |            "description": "OK",
+        |            "schema": {
+        |              "type": "array",
+        |              "items": {
+        |                "type": "object",
+        |                "properties": {
+        |                  "id": { "type": "integer" },
+        |                  "name": { "type": "string" }
+        |                }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val result = Parser.parseContent(spec)
+    assertEquals(result.endpoints.size, 1)
+    // Array responses get wrapped in "data" key
+    assert(result.endpoints.head.responseSchema.properties.contains("data"))
+  }
+
+  test("Swagger 2.0: query parameters parse") {
+    val spec =
+      """{
+        |  "swagger": "2.0",
+        |  "info": { "title": "Test", "version": "1.0" },
+        |  "paths": {
+        |    "/users": {
+        |      "get": {
+        |        "produces": ["application/json"],
+        |        "parameters": [
+        |          { "name": "page", "in": "query", "type": "integer", "required": false },
+        |          { "name": "limit", "in": "query", "type": "integer", "required": true }
+        |        ],
+        |        "responses": {
+        |          "200": {
+        |            "description": "OK",
+        |            "schema": {
+        |              "type": "object",
+        |              "properties": {
+        |                "id": { "type": "integer" }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val result = Parser.parseContent(spec)
+    val ep = result.endpoints.head
+    assertEquals(ep.queryParams.size, 2)
+
+    val pageParam = ep.queryParams.find(_.name == "page").get
+    assert(!pageParam.required)
+
+    val limitParam = ep.queryParams.find(_.name == "limit").get
+    assert(limitParam.required)
+  }
+
+  test("Swagger 2.0: definitions references work") {
+    // Swagger 2.0 uses "definitions" instead of "components/schemas"
+    val spec =
+      """{
+        |  "swagger": "2.0",
+        |  "info": { "title": "Test", "version": "1.0" },
+        |  "definitions": {
+        |    "User": {
+        |      "type": "object",
+        |      "properties": {
+        |        "id": { "type": "integer" },
+        |        "email": { "type": "string" }
+        |      }
+        |    }
+        |  },
+        |  "paths": {
+        |    "/users": {
+        |      "get": {
+        |        "produces": ["application/json"],
+        |        "responses": {
+        |          "200": {
+        |            "description": "OK",
+        |            "schema": { "$ref": "#/definitions/User" }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val result = Parser.parseContent(spec)
+    assertEquals(result.endpoints.size, 1)
+    val props = result.endpoints.head.responseSchema.properties
+    assert(props("id").isInstanceOf[OpenAPISchema.IntegerType])
+    assert(props("email").isInstanceOf[OpenAPISchema.StringType])
+  }
+
+  test("Swagger 2.0: baseUrl is constructed from host/basePath/schemes") {
+    val spec =
+      """{
+        |  "swagger": "2.0",
+        |  "info": { "title": "Test", "version": "1.0" },
+        |  "host": "api.example.com",
+        |  "basePath": "/v2",
+        |  "schemes": ["https"],
+        |  "paths": {
+        |    "/items": {
+        |      "get": {
+        |        "produces": ["application/json"],
+        |        "responses": {
+        |          "200": {
+        |            "description": "OK",
+        |            "schema": {
+        |              "type": "object",
+        |              "properties": { "id": { "type": "integer" } }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+
+    val result = Parser.parseContent(spec)
+    // SwaggerConverter constructs servers[0].url from host+basePath+schemes
+    assertEquals(result.baseUrl, "https://api.example.com/v2")
+  }
+
+  test("Swagger 2.0: Petstore spec from URL".tag(munit.Slow)) {
+    // Integration test - fetches real Petstore 2.0 spec
+    // Note: This test is tagged Slow and may be skipped in CI if petstore.swagger.io is down
+    val result = Parser.parse("https://petstore.swagger.io/v2/swagger.json")
+
+    // Should find multiple GET endpoints
+    assert(result.endpoints.nonEmpty, "Expected endpoints from Petstore spec")
+
+    // Check for known endpoints
+    val paths = result.endpoints.map(_.path).toSet
+    assert(paths.contains("/pet/findByStatus"), s"Expected /pet/findByStatus, got: $paths")
+
+    // Check baseUrl was extracted
+    assertEquals(result.baseUrl, "https://petstore.swagger.io/v2")
+
+    // Check Pet schema from /pet/findByStatus (array of Pet)
+    val findByStatus = result.endpoints.find(_.path == "/pet/findByStatus").get
+    // Array response gets wrapped in "data" key
+    assert(findByStatus.responseSchema.properties.contains("data"))
+  }
 }


### PR DESCRIPTION
Closes #138

## Summary
- Parser auto-detects spec version and converts Swagger 2.0 → OpenAPI 3.0
- Uses `SwaggerConverter` from swagger-parser as fallback
- All schema types, query params, and `$ref` definitions work
- Updated README to document supported spec versions

## Test plan
- [x] Added 5 Swagger 2.0 compatibility tests
- [x] All 237 tests pass
- [x] Manual test with real Swagger 2.0 spec (e.g., Petstore 2.0)