### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Turn any REST API with an OpenAPI spec into queryable Apache Spark tables.
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.neutrinic" %% "apilytics" % "0.6.0"
+libraryDependencies += "io.github.neutrinic" %% "apilytics" % "0.7.0"
 ```
 
 ```bash
 # spark-submit
-spark-submit --packages io.github.neutrinic:apilytics_2.13:0.6.0 your-app.jar
+spark-submit --packages io.github.neutrinic:apilytics_2.13:0.7.0 your-app.jar
 
 # spark-shell
-spark-shell --packages io.github.neutrinic:apilytics_2.13:0.6.0
+spark-shell --packages io.github.neutrinic:apilytics_2.13:0.7.0
 ```
 
 Then configure the catalog:

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "io.github.neutrinic"
-ThisBuild / version := "0.6.0"
+ThisBuild / version := "0.7.0"
 ThisBuild / scalaVersion := "2.13.16"
 
 // Publishing settings for Maven Central


### PR DESCRIPTION
Closes #148

## Summary
- Bump version from 0.6.0 to 0.7.0 in `build.sbt` and `README.md` (installation instructions)

## Test plan
- [x] Version string updated in `build.sbt`
- [x] Version string updated in 3 places in `README.md` (sbt dep, spark-submit, spark-shell)