### PR TITLE
Redact sensitive data in ApiError exception messages

### DIFF
--- a/src/main/scala/com/apilytics/core/http/ApiError.scala
+++ b/src/main/scala/com/apilytics/core/http/ApiError.scala
@@ -28,10 +28,10 @@ final case class ApiError(
 ) extends RuntimeException(message, cause.orNull) {
 
   override def getMessage: String = {
-    val paramsStr = if (params.isEmpty) "" else s"?${params.toSeq.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString("&")}"
+    val paramsStr = ApiError.renderParams(params)
     val requestIdStr = requestId.map(id => s"\n  Request-ID: $id").getOrElse("")
     val retryStr = if (retryAttempt > 0) s" (after $retryAttempt retries)" else ""
-    val bodyPreview = if (responseBody.length > 500) responseBody.take(500) + "..." else responseBody
+    val bodyPreview = if (responseBody.length > 200) responseBody.take(200) + "..." else responseBody
 
     s"""API Error: $message$retryStr
        |  ${method.name} $endpoint$paramsStr
@@ -80,6 +80,31 @@ object ApiError {
     requestId = extractRequestId(headers),
     retryAttempt = retryAttempt
   )
+
+  /** Regex for sensitive parameter names. Matches common credential-bearing keys
+    * such as api_key, access_token, password, client_secret, authorization, etc.
+    */
+  private val sensitiveKeyPattern = "(?i).*(key|token|pass|secret|auth|credential).*".r
+
+  /** Redact values for params whose keys match sensitive patterns.
+    * Returns a copy with sensitive values replaced by `[REDACTED]`.
+    */
+  def redactParams(params: Map[String, String]): Map[String, String] =
+    params.map {
+      case (k, _) if sensitiveKeyPattern.matches(k) => k -> "[REDACTED]"
+      case kv => kv
+    }
+
+  /** Render params as a query string with sensitive values redacted.
+    * Returns empty string if params is empty, otherwise `?k1=v1&k2=v2`.
+    */
+  def renderParams(params: Map[String, String]): String = {
+    if (params.isEmpty) ""
+    else {
+      val safe = redactParams(params)
+      "?" + safe.toSeq.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString("&")
+    }
+  }
 
   /** Create a generic HTTP error. */
   def httpError(

--- a/src/main/scala/com/apilytics/spark/ErrorHandler.scala
+++ b/src/main/scala/com/apilytics/spark/ErrorHandler.scala
@@ -60,7 +60,7 @@ object ErrorHandler {
       case s if s >= 500 => s"Server error ($s)"
       case s => s"HTTP error ($s)"
     }
-    val paramsStr = if (e.params.isEmpty) "" else "?" + e.params.map { case (k, v) => s"$k=$v" }.mkString("&")
+    val paramsStr = ApiError.renderParams(e.params)
     s"""$status
        |  ${e.method.name} ${e.endpoint}$paramsStr
        |  ${e.message}""".stripMargin.trim

--- a/src/test/scala/com/apilytics/core/http/ApiErrorSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/ApiErrorSuite.scala
@@ -41,8 +41,8 @@ class ApiErrorSuite extends FunSuite {
     assert(msg.contains("after 3 retries"))
   }
 
-  test("getMessage truncates long response body") {
-    val longBody = "x" * 600
+  test("getMessage truncates long response body at 200 chars") {
+    val longBody = "x" * 300
     val error = ApiError(
       message = "Bad Request",
       endpoint = "/api",
@@ -56,7 +56,9 @@ class ApiErrorSuite extends FunSuite {
 
     val msg = error.getMessage
     assert(msg.contains("..."))
-    assert(msg.length < longBody.length + 200) // significantly truncated
+    val bodyLine = msg.split("\n").find(_.contains("Response:")).get
+    // "  Response: " (12 chars) + 200 truncated + "..." (3 chars) = 215
+    assert(bodyLine.length <= 215, s"Body line too long: ${bodyLine.length}")
   }
 
   test("getMessage omits Request-ID when not present") {
@@ -134,5 +136,84 @@ class ApiErrorSuite extends FunSuite {
     assertEquals(error.message, "Authentication failed")
     assertEquals(error.statusCode, 401)
     assertEquals(error.requestId, Some("auth-req-1"))
+  }
+
+  test("redactParams redacts sensitive keys") {
+    val params = Map(
+      "api_key" -> "sk-12345",
+      "limit" -> "10",
+      "access_token" -> "ghp_abc123",
+      "offset" -> "0"
+    )
+    val redacted = ApiError.redactParams(params)
+    assertEquals(redacted("api_key"), "[REDACTED]")
+    assertEquals(redacted("access_token"), "[REDACTED]")
+    assertEquals(redacted("limit"), "10")
+    assertEquals(redacted("offset"), "0")
+  }
+
+  test("redactParams is case-insensitive") {
+    val params = Map(
+      "API_KEY" -> "secret",
+      "X-Auth-Token" -> "secret",
+      "Password" -> "secret",
+      "CLIENT_SECRET" -> "secret"
+    )
+    val redacted = ApiError.redactParams(params)
+    assert(redacted.values.forall(_ == "[REDACTED]"))
+  }
+
+  test("redactParams leaves non-sensitive keys unchanged") {
+    val params = Map("limit" -> "10", "offset" -> "0", "page" -> "1", "sort" -> "name")
+    val redacted = ApiError.redactParams(params)
+    assertEquals(redacted, params)
+  }
+
+  test("renderParams returns empty string for empty params") {
+    assertEquals(ApiError.renderParams(Map.empty), "")
+  }
+
+  test("renderParams redacts sensitive values in query string") {
+    val params = Map("api_key" -> "secret123", "limit" -> "10")
+    val result = ApiError.renderParams(params)
+    assert(result.contains("api_key=[REDACTED]"))
+    assert(result.contains("limit=10"))
+    assert(!result.contains("secret123"))
+  }
+
+  test("getMessage redacts sensitive params") {
+    val error = ApiError(
+      message = "Unauthorized",
+      endpoint = "/api/data",
+      method = Method.GET,
+      params = Map("api_key" -> "sk-secret-key", "limit" -> "10"),
+      statusCode = 401,
+      responseBody = "Unauthorized",
+      requestId = None,
+      retryAttempt = 0
+    )
+
+    val msg = error.getMessage
+    assert(msg.contains("api_key=[REDACTED]"))
+    assert(msg.contains("limit=10"))
+    assert(!msg.contains("sk-secret-key"))
+  }
+
+  test("original params remain accessible for programmatic use") {
+    val error = ApiError(
+      message = "Error",
+      endpoint = "/api",
+      method = Method.GET,
+      params = Map("api_key" -> "sk-secret-key"),
+      statusCode = 401,
+      responseBody = "",
+      requestId = None,
+      retryAttempt = 0
+    )
+
+    // Case class field retains original value
+    assertEquals(error.params("api_key"), "sk-secret-key")
+    // But getMessage is redacted
+    assert(!error.getMessage.contains("sk-secret-key"))
   }
 }

--- a/src/test/scala/com/apilytics/spark/ErrorHandlerSuite.scala
+++ b/src/test/scala/com/apilytics/spark/ErrorHandlerSuite.scala
@@ -55,4 +55,27 @@ class ErrorHandlerSuite extends FunSuite {
     val ex = ApiException("Test error")
     assertEquals(ex.toString, "ApiException: Test error")
   }
+
+  test("ApiError with sensitive params is redacted in clean error") {
+    val apiError = ApiError(
+      message = "Authentication failed",
+      endpoint = "/v1/users",
+      method = Method.GET,
+      params = Map("api_key" -> "sk-secret", "limit" -> "10"),
+      statusCode = 401,
+      responseBody = """{"error": "invalid_token"}""",
+      requestId = Some("req-123"),
+      retryAttempt = 0
+    )
+
+    val ex = intercept[ApiException] {
+      ErrorHandler.withCleanErrors {
+        throw apiError
+      }
+    }
+
+    assert(ex.getMessage.contains("api_key=[REDACTED]"))
+    assert(ex.getMessage.contains("limit=10"))
+    assert(!ex.getMessage.contains("sk-secret"))
+  }
 }


### PR DESCRIPTION
Closes #140

## Summary
- Add `redactParams()` and `renderParams()` to `ApiError` companion object — redacts values for param keys matching `key|token|pass|secret|auth|credential` (case-insensitive)
- `ApiError.getMessage` now uses redacted rendering instead of raw params, and truncates response body at 200 chars (down from 500)
- `ErrorHandler.formatApiError` uses the same centralized `renderParams()` for consistent redaction
- Original `params` field retains unredacted values for programmatic access

## Test plan
- [x] `redactParams` redacts sensitive keys (`api_key`, `access_token`) but leaves safe keys (`limit`, `offset`)
- [x] `redactParams` is case-insensitive (`API_KEY`, `Password`, `CLIENT_SECRET`)
- [x] `renderParams` returns empty string for empty params, redacts in query string output
- [x] `getMessage` doesn't contain raw secret values
- [x] Original params remain accessible on the case class
- [x] `ErrorHandler` path also redacts sensitive params
- [x] Response body truncation updated to 200 chars
- [x] All 308 tests pass (304 passed, 4 skipped)