### PR TITLE
Enable sbt-ci-release plugin for Maven Central publishing

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
-// TODO: uncomment before release (commented out for worktree compatibility)
-// addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")


### PR DESCRIPTION
## Summary
- Uncomment `sbt-ci-release` plugin in `project/plugins.sbt` — was commented out for worktree compatibility but is required by the release workflow (`sbt ci-release`)
- The v0.7.0 release workflow failed because this plugin was missing

## Test plan
- [x] Plugin uncommented
- [ ] After merge: delete and re-push `v0.7.0` tag to re-trigger release workflow