### PR TITLE
Limit error response body size to prevent OOM

### DIFF
--- a/src/main/scala/com/apilytics/core/http/Client.scala
+++ b/src/main/scala/com/apilytics/core/http/Client.scala
@@ -203,7 +203,7 @@ object Client {
               case code =>
                 // Non-retryable error - release connection and raise error
                 Stream.eval(
-                  resp.as[String].flatMap { body =>
+                  readErrorBody(resp).flatMap { body =>
                     release *> IO.raiseError(ApiError.httpError(
                       endpoint = req.uri.path.renderString,
                       method = req.method,
@@ -271,7 +271,7 @@ object Client {
               }
 
           case 401 | 403 =>
-            resp.as[String].flatMap { body =>
+            readErrorBody(resp).flatMap { body =>
               IO.raiseError(ApiError.authFailed(
                 endpoint = endpoint,
                 method = req.method,
@@ -284,7 +284,7 @@ object Client {
             }
 
           case code =>
-            resp.as[String].flatMap { body =>
+            readErrorBody(resp).flatMap { body =>
               IO.raiseError(ApiError.httpError(
                 endpoint = endpoint,
                 method = req.method,
@@ -305,6 +305,15 @@ object Client {
         case e => IO.raiseError(e)
       }
     }
+
+    /** Read at most `maxBytes` from an error response body to prevent OOM.
+      * A malicious or misconfigured server could return a multi-GB error page;
+      * we cap it at 4 KB which is plenty for diagnostic messages.
+      */
+    private val MaxErrorBodyBytes: Long = 4096
+
+    private def readErrorBody(resp: org.http4s.Response[IO]): IO[String] =
+      resp.body.take(MaxErrorBodyBytes).through(fs2.text.utf8.decode).compile.string
 
     /** Check if an exception is a transient network error worth retrying. */
     private def isTransientNetworkError(e: Throwable): Boolean = {

--- a/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
+++ b/src/test/scala/com/apilytics/core/http/WireMockSuite.scala
@@ -1701,4 +1701,24 @@ class WireMockSuite extends FunSuite {
       Files.deleteIfExists(tmpDir)
     }
   }
+
+  // ============== ERROR BODY SIZE LIMIT TESTS ==============
+
+  test("large error response body is truncated to prevent OOM") {
+    // Simulate a server returning a massive error body (10 KB)
+    val largeBody = "x" * 10000
+    server.stubFor(
+      get(urlPathEqualTo("/large-error"))
+        .willReturn(aResponse().withStatus(400).withBody(largeBody))
+    )
+
+    val error = intercept[ApiError] {
+      Client.resource(defaultHttp.copy(maxRetries = 0), noAuth).use { client =>
+        client.get(baseUri.addPath("large-error"))
+      }.unsafeRunSync()
+    }
+
+    // Error body should be capped at 4096 bytes, not the full 10000
+    assert(error.responseBody.length <= 4096, s"Response body too large: ${error.responseBody.length}")
+  }
 }


### PR DESCRIPTION
Closes #141

## Summary
- Added bounded `readErrorBody` helper (4 KB cap via `fs2.Stream.take`) to prevent OOM from malicious/misconfigured servers returning multi-GB error pages
- Replaced all 3 unbounded `resp.as[String]` calls in error paths with the bounded reader
- Added WireMock test verifying 10 KB error body is truncated to ≤ 4096 bytes

## Test plan
- [x] All 309 tests pass (`sbt test`)
- [x] New test: `large error response body is truncated to prevent OOM`