### PR TITLE
Document secure credential management practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ tmpclaude-*
 
 # Claude
 CLAUDE.md
+
+# User config files (may contain credentials)
+*.local.conf

--- a/README.md
+++ b/README.md
@@ -434,6 +434,34 @@ docker compose -f compose.spark.yaml up -d
 
 This starts a Spark master, two workers, and a history server. The assembled JAR is mounted automatically.
 
+## Security: Credential Management
+
+API tokens, passwords, and client secrets should **never** be hardcoded in config files that are committed to version control. Apilytics uses [Typesafe Config](https://github.com/lightbend/config), which supports environment variable substitution natively.
+
+**Do** -- use environment variables:
+```hocon
+auth {
+  type = "bearer"
+  token = ${API_TOKEN}         # resolved at load time from $API_TOKEN
+}
+```
+
+**Don't** -- hardcode secrets:
+```hocon
+auth {
+  type = "bearer"
+  token = "ghp_abc123secret"   # NEVER do this -- secrets leak to git history
+}
+```
+
+Use `${VAR}` for required variables (fails if unset) or `${?VAR}` for optional ones (resolves to absent if unset).
+
+**Best practices:**
+- Export credentials in your shell: `export API_TOKEN=ghp_xxxxx`
+- Keep local config files with credentials out of git (add `*.local.conf` to `.gitignore`)
+- For CI/CD, use your platform's secret management (GitHub Actions secrets, Vault, etc.)
+- For OAuth2 client credentials, store both `client-id` and `client-secret` as environment variables
+
 ## Architecture
 
 ```

--- a/examples/github/github-config.conf
+++ b/examples/github/github-config.conf
@@ -37,6 +37,9 @@ cache {
 # Authentication
 # -----------------------------------------------------------------------------
 # Supported types: none, bearer, basic, header, oauth2_client
+#
+# SECURITY: Never hardcode tokens in config files committed to version control.
+# Use environment variable substitution: ${VAR_NAME} or ${?VAR_NAME} (optional).
 auth {
   type = "none"
 }

--- a/examples/slack/slack-config.conf
+++ b/examples/slack/slack-config.conf
@@ -28,6 +28,8 @@
 openapi = "/opt/spark/examples/slack/slack-openapi.json"
 
 # Bearer token auth using bot token
+# SECURITY: Never hardcode tokens in config files committed to version control.
+# Use environment variable substitution: ${VAR_NAME} or ${?VAR_NAME} (optional).
 auth {
   type = "bearer"
   token = ${SLACK_BOT_TOKEN}


### PR DESCRIPTION
Closes #142

## Summary
- Added "Security: Credential Management" section to README with DO/DON'T HOCON examples and best practices
- Added security comments to auth blocks in GitHub and Slack example configs
- Added `*.local.conf` to `.gitignore` for user config files that may contain credentials

## Test plan
- [x] Documentation-only changes -- no code modified
- [x] Verified `.gitignore` pattern added