### PR TITLE
Add OWASP dependency check to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,32 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * 1'  # Monday 8am UTC
+  workflow_dispatch:
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: OWASP Dependency Check
+        run: sbt dependencyCheck
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: target/dependency-check/

--- a/build.sbt
+++ b/build.sbt
@@ -98,4 +98,9 @@ lazy val root = (project in file("."))
     assembly / test := {},
   )
 
+// OWASP dependency check
+dependencyCheckFailBuildOnCVSS := 9  // only fail on critical (9+)
+dependencyCheckOutputDirectory := Some(target.value / "dependency-check")
+dependencyCheckFormats := Seq("HTML", "JSON")
+
 addCommandAlias("build", "assembly")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
+addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "5.1.0")


### PR DESCRIPTION
Closes #143

## Summary
- Added `sbt-dependency-check` plugin (5.1.0) with CVSS 9 threshold (critical only)
- Created dedicated `security.yml` workflow -- runs on push to main, weekly Monday schedule, and manual dispatch
- Reports uploaded as artifacts (HTML for review, JSON for automation)
- Added `dependabot.yml` for weekly GitHub Actions version updates

## Test plan
- [x] Plugin and build config verified against sbt-dependency-check docs
- [x] Workflow YAML follows existing CI patterns (Java 17, Temurin, sbt/setup-sbt)
- [ ] First security scan will run on merge to main