### PR TITLE
Fix OWASP dependency check with NVD API key

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: OWASP Dependency Check
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: sbt dependencyCheck
 
       - name: Upload report

--- a/build.sbt
+++ b/build.sbt
@@ -99,8 +99,17 @@ lazy val root = (project in file("."))
   )
 
 // OWASP dependency check
+import net.nmoncho.sbt.dependencycheck.settings._
 dependencyCheckFailBuildOnCVSS := 9  // only fail on critical (9+)
-dependencyCheckOutputDirectory := Some(target.value / "dependency-check")
-dependencyCheckFormats := Seq("HTML", "JSON")
+dependencyCheckOutputDirectory := target.value / "dependency-check"
+dependencyCheckFormats := {
+  import org.owasp.dependencycheck.reporting.ReportGenerator.Format
+  Seq(Format.HTML, Format.JSON)
+}
+dependencyCheckNvdApi := {
+  val key = sys.env.getOrElse("NVD_API_KEY", "")
+  if (key.nonEmpty) NvdApiSettings(apiKey = key)
+  else NvdApiSettings()
+}
 
 addCommandAlias("build", "assembly")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
-addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "5.1.0")
+addSbtPlugin("net.nmoncho" % "sbt-dependency-check" % "1.8.5")


### PR DESCRIPTION
Closes #159

## Summary
- Switched plugin from `net.vonbuchholtz:sbt-dependency-check:5.1.0` (old fork, no API key support) to `net.nmoncho:sbt-dependency-check:1.8.5` (active fork with NVD API key support)
- Added `dependencyCheckNvdApi` config in `build.sbt` to read `NVD_API_KEY` from environment
- Passed `NVD_API_KEY` secret as env var in `security.yml` workflow

## Test plan
- [x] `NVD_API_KEY` secret already configured in repo settings
- [ ] Security workflow passes after merge to main