### PR TITLE
Fix NVD API 429 rate limiting in dependency check

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,7 @@ dependencyCheckFormats := {
 }
 dependencyCheckNvdApi := {
   val key = sys.env.getOrElse("NVD_API_KEY", "")
-  if (key.nonEmpty) NvdApiSettings(apiKey = key)
+  if (key.nonEmpty) NvdApiSettings(apiKey = key, requestDelay = Some(java.time.Duration.ofSeconds(4)))
   else NvdApiSettings()
 }
 


### PR DESCRIPTION
Closes #164

## Summary
- Added `requestDelay = Some(4.seconds)` to `NvdApiSettings` to avoid NVD API 429 rate limiting during initial database download

## Test plan
- [ ] Security workflow passes after merge to main