### PR TITLE
Lower OWASP CVSS threshold to 7 and suppress provided-scope CVEs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,10 @@ lazy val root = (project in file("."))
 
 // OWASP dependency check
 import net.nmoncho.sbt.dependencycheck.settings._
-dependencyCheckFailBuildOnCVSS := 9  // only fail on critical (9+)
+dependencyCheckFailBuildOnCVSS := 7  // fail on high + critical (7+)
+dependencyCheckSuppressions := SuppressionSettings(
+  files = SuppressionFilesSettings.files()(file("dependency-check-suppression.xml"))
+)
 dependencyCheckOutputDirectory := target.value / "dependency-check"
 dependencyCheckFormats := {
   import org.owasp.dependencycheck.reporting.ReportGenerator.Format

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+  <!--
+    Spark and Hadoop are "provided" dependencies - they are not shipped in
+    our assembly JAR. CVEs in these transitive deps are the responsibility
+    of the Spark runtime environment, not this project.
+  -->
+
+  <!-- Hadoop 3.4.1 transitive deps (provided by Spark runtime) -->
+  <suppress>
+    <notes>Hadoop is a provided dependency, not shipped in our JAR</notes>
+    <filePath regex="true">.*hadoop-.*\.jar.*</filePath>
+    <cve>CVE-2025-27821</cve>
+  </suppress>
+
+  <!-- Avro (transitive via Spark/Hadoop, provided scope) -->
+  <suppress>
+    <notes>Avro is a transitive dep from Spark/Hadoop, provided scope</notes>
+    <filePath regex="true">.*avro-.*\.jar.*</filePath>
+    <cve>CVE-2023-37475</cve>
+  </suppress>
+
+  <!-- jQuery bundled inside avro-ipc JAR (not used at runtime) -->
+  <suppress>
+    <notes>jQuery bundled in avro-ipc is not used by this project</notes>
+    <filePath regex="true">.*avro-ipc.*jquery.*</filePath>
+    <cve>CVE-2015-9251</cve>
+    <cve>CVE-2012-6708</cve>
+    <cve>CVE-2020-7656</cve>
+    <cve>CVE-2020-11023</cve>
+    <cve>CVE-2019-11358</cve>
+    <cve>CVE-2020-11022</cve>
+  </suppress>
+
+  <!-- Janino compiler (transitive via Spark, provided scope) -->
+  <suppress>
+    <notes>Janino is a transitive dep from Spark, provided scope</notes>
+    <filePath regex="true">.*commons-compiler.*\.jar</filePath>
+    <cve>CVE-2023-33546</cve>
+  </suppress>
+
+  <!-- commons-lang3 (transitive via Spark/Hadoop, provided scope) -->
+  <suppress>
+    <notes>commons-lang3 is a transitive dep from Spark, provided scope</notes>
+    <filePath regex="true">.*commons-lang3.*\.jar</filePath>
+    <cve>CVE-2025-48924</cve>
+  </suppress>
+
+  <!-- jackson-databind bundled inside hadoop-client-runtime (provided scope) -->
+  <suppress>
+    <notes>jackson-databind inside hadoop-client-runtime, provided scope</notes>
+    <filePath regex="true">.*hadoop-client-runtime.*jackson-databind.*</filePath>
+    <cve>CVE-2023-35116</cve>
+  </suppress>
+
+  <!-- commons-beanutils bundled inside hadoop-client-runtime (provided scope) -->
+  <suppress>
+    <notes>commons-beanutils inside hadoop-client-runtime, provided scope</notes>
+    <filePath regex="true">.*hadoop-client-runtime.*commons-beanutils.*</filePath>
+    <cve>CVE-2025-48734</cve>
+  </suppress>
+
+</suppressions>


### PR DESCRIPTION
Closes #162

## Summary
- Lowered `dependencyCheckFailBuildOnCVSS` from 9 to 7 to catch high-severity deserialization/parsing CVEs
- Added `dependency-check-suppression.xml` for CVEs in Spark/Hadoop transitive deps (provided scope, not shipped in assembly JAR):
  - CVE-2025-27821 (Hadoop 3.4.1)
  - CVE-2023-37475 (Avro 1.12.0)
  - CVE-2023-33546 (Janino 3.1.9)
  - CVE-2025-48924 (commons-lang3)
  - CVE-2023-35116 (jackson-databind in hadoop-client-runtime)
  - CVE-2025-48734 (commons-beanutils in hadoop-client-runtime)
  - jQuery CVEs bundled inside avro-ipc JAR

## Test plan
- [ ] Security workflow passes after merge to main