### PR TITLE
Warn when credentials are configured over plaintext HTTP

### DIFF
--- a/src/main/scala/com/apilytics/core/config/Loader.scala
+++ b/src/main/scala/com/apilytics/core/config/Loader.scala
@@ -1,11 +1,14 @@
 package com.apilytics.core.config
 
 import com.typesafe.config.{Config, ConfigFactory}
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 object Loader {
+
+  private val log = LoggerFactory.getLogger(getClass)
 
   def load(path: String): SourceConfig = {
     val config = ConfigFactory.parseFile(new java.io.File(path)).resolve()
@@ -47,6 +50,9 @@ object Loader {
         }
       }
     }
+
+    // Warn when auth credentials are configured over plaintext HTTP
+    warnPlaintextCredentials(sc)
 
     sc
   }
@@ -362,6 +368,36 @@ object Loader {
     }
 
     cc
+  }
+
+  /** Check if auth credentials would be sent over plaintext HTTP and warn.
+    * This catches accidental `http://` typos that would leak Bearer tokens,
+    * Basic Auth credentials, or API keys in plaintext.
+    */
+  private[config] def warnPlaintextCredentials(sc: SourceConfig): List[String] = {
+    if (sc.auth.authType == AuthType.None) return Nil
+
+    val warnings = List.newBuilder[String]
+
+    sc.baseUrl.foreach { url =>
+      if (url.toLowerCase.startsWith("http://")) {
+        val msg = s"SECURITY: base-url uses plaintext HTTP ($url). " +
+          "Credentials will be sent unencrypted. Use https:// instead."
+        log.warn(msg)
+        warnings += msg
+      }
+    }
+
+    sc.auth.tokenUrl.foreach { url =>
+      if (url.toLowerCase.startsWith("http://")) {
+        val msg = s"SECURITY: token-url uses plaintext HTTP ($url). " +
+          "OAuth2 client credentials will be sent unencrypted. Use https:// instead."
+        log.warn(msg)
+        warnings += msg
+      }
+    }
+
+    warnings.result()
   }
 
   private def optional(config: Config, path: String): Option[String] =

--- a/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
+++ b/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
@@ -661,4 +661,98 @@ class LoaderSuite extends FunSuite {
     val result = Loader.load(config)
     assertEquals(result.tables("events").checkpoint, None)
   }
+
+  // ==========================================================================
+  // Plaintext HTTP credential warning tests (#163)
+  // ==========================================================================
+
+  test("warns when base-url uses plaintext HTTP with auth") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |base-url = "http://api.example.com"
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    val warnings = Loader.warnPlaintextCredentials(result)
+    assertEquals(warnings.size, 1)
+    assert(warnings.head.contains("base-url"))
+    assert(warnings.head.contains("http://api.example.com"))
+  }
+
+  test("warns when token-url uses plaintext HTTP") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth {
+        |  type = oauth2_client
+        |  client-id = "id"
+        |  client-secret = "secret"
+        |  token-url = "http://auth.example.com/token"
+        |}
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    val warnings = Loader.warnPlaintextCredentials(result)
+    assertEquals(warnings.size, 1)
+    assert(warnings.head.contains("token-url"))
+    assert(warnings.head.contains("http://auth.example.com/token"))
+  }
+
+  test("warns for both base-url and token-url over HTTP") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth {
+        |  type = oauth2_client
+        |  client-id = "id"
+        |  client-secret = "secret"
+        |  token-url = "http://auth.example.com/token"
+        |}
+        |base-url = "http://api.example.com"
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    val warnings = Loader.warnPlaintextCredentials(result)
+    assertEquals(warnings.size, 2)
+  }
+
+  test("no warning when URLs use HTTPS") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |base-url = "https://api.example.com"
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    val warnings = Loader.warnPlaintextCredentials(result)
+    assertEquals(warnings.size, 0)
+  }
+
+  test("no warning when auth type is none") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = none }
+        |base-url = "http://api.example.com"
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    val warnings = Loader.warnPlaintextCredentials(result)
+    assertEquals(warnings.size, 0)
+  }
+
+  test("no warning when base-url is not set") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    val warnings = Loader.warnPlaintextCredentials(result)
+    assertEquals(warnings.size, 0)
+  }
 }


### PR DESCRIPTION
Closes #163

## Summary
- Add `warnPlaintextCredentials()` in `Loader` that checks `base-url` and `token-url` for `http://` when auth is configured
- Logs WARN-level messages via SLF4J when credentials would be sent unencrypted
- Skips check when auth type is `none` (no credentials to leak)

## Test plan
- 6 new tests in `LoaderSuite`: HTTP base-url, HTTP token-url, both HTTP, HTTPS (no warn), auth=none (no warn), no base-url (no warn)
- All 328 tests pass