### PR TITLE
Fix failing OWASP dependency check (#181)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,18 @@ lazy val root = (project in file("."))
       "org.wiremock"      % "wiremock"            % "3.10.0" % Test,
     ),
 
+    // Security bumps for transitive deps pulled in by swagger-parser.
+    dependencyOverrides ++= Seq(
+      // CVE-2026-54512/54513/54514/54515 (polymorphic type validator bypasses,
+      // eager DNS resolution). Fixed in 2.18.8 / 2.18.9 — stay on the 2.18 line
+      // to match the Jackson that Spark 4.0.0 provides at runtime.
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.9",
+      // CVE-2025-66453 (DoS via Number.toFixed on crafted floats), reached
+      // through json-schema-validator's ECMA-262 regex format checker.
+      // Fixed in 1.7.14.1 / 1.7.15.1 / 1.8.1.
+      "org.mozilla" % "rhino" % "1.7.15.1",
+    ),
+
     scalacOptions ++= Seq(
       "-encoding", "UTF-8",
       "-deprecation",

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -33,4 +33,28 @@
     <cve>CVE-2025-48924</cve>
   </suppress>
 
+  <!--
+    False positive: CVE-2026-25087 is a use-after-free in Apache Arrow C++
+    (IPC file reader with pre-buffering). The Java implementation is a separate
+    codebase and is not affected; the match comes from the shared
+    cpe:2.3:a:apache:arrow CPE.
+  -->
+  <suppress>
+    <notes>Arrow Java flagged for an Arrow C++ CVE (shared CPE)</notes>
+    <filePath regex="true">.*arrow-(format|vector|memory-core|memory-netty|memory-netty-buffer-patch)-.*\.jar</filePath>
+    <cve>CVE-2026-25087</cve>
+  </suppress>
+
+  <!--
+    False positive: CVE-2025-15104 is an SSRF in the Nu Html Checker
+    (validator.nu), an unrelated project. Matched via the generic
+    cpe:2.3:a:validator:validator / json-schema CPEs on json-schema-validator,
+    a transitive dep of swagger-parser.
+  -->
+  <suppress>
+    <notes>json-schema-validator flagged for a validator.nu CVE (CPE mismatch)</notes>
+    <filePath regex="true">.*json-schema-validator-.*\.jar</filePath>
+    <cve>CVE-2025-15104</cve>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
Closes #181

## Summary

The `Security` workflow has been failing on `main` with `Vulnerability with CVSS score higher than [7.0] found`. Four findings; two real, two CPE false positives.

**Real — bumped via `dependencyOverrides` (both are transitive through `swagger-parser`):**
- `jackson-databind` 2.18.0 → **2.18.9** — CVE-2026-54512 / 54513 (8.1, PolymorphicTypeValidator bypasses via generic type IDs and array component types), CVE-2026-54514 (eager DNS resolution in `JDKFromStringDeserializer`), CVE-2026-54515. All fixed by 2.18.9. Stayed on the 2.18 line to match the Jackson that Spark 4.0.0 provides at runtime.
- `rhino` 1.7.7.2 → **1.7.15.1** — CVE-2025-66453 (7.5, DoS via `Number.toFixed` on crafted floats). Reached through `json-schema-validator`'s ECMA-262 regex format checker.

**False positives — suppressed with notes:**
- Arrow Java 18.1.0 / CVE-2026-25087 — the CVE is a use-after-free in Apache Arrow **C++** (IPC file reader with pre-buffering enabled). The Java implementation is a separate codebase; the match comes from the shared `cpe:2.3:a:apache:arrow` CPE.
- `json-schema-validator` 2.2.14 / CVE-2025-15104 — the CVE is an SSRF in the Nu Html Checker (validator.nu), an unrelated project. Matched via the generic `cpe:2.3:a:validator:validator` CPE.

## Test plan
- [x] `sbt test` — 328 tests pass, including the Swagger 2.0 suite that exercises the `json-schema-validator` → rhino path
- [x] Verified the overrides resolve: `jackson-databind-2.18.9.jar` and `rhino-1.7.15.1.jar` on the dependency classpath
- [x] `Security` workflow passes on this branch