### PR TITLE
Upgrade to Spark 4.1 (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.neutrinic/apilytics_2.13.svg)](https://central.sonatype.com/artifact/io.github.neutrinic/apilytics_2.13)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Scala](https://img.shields.io/badge/Scala-2.13-red.svg)](https://www.scala-lang.org/)
-[![Spark](https://img.shields.io/badge/Spark-4.0-orange.svg)](https://spark.apache.org/)
+[![Spark](https://img.shields.io/badge/Spark-4.1-orange.svg)](https://spark.apache.org/)
 
 Turn any REST API with an OpenAPI spec into queryable Apache Spark tables.
+
+Built and tested against **Spark 4.1** on Scala 2.13 / Java 17. Spark is a `provided`
+dependency, so the connector also runs on Spark 4.0 clusters — the Data Source V2 and
+Arrow columnar APIs it uses are unchanged between the two.
 
 ## Installation
 
@@ -322,7 +326,7 @@ Control how OpenAPI schemas are used with the `mode` setting:
 
 **Strict mode** (default) uses the OpenAPI schema to produce typed columns. Nested objects are flattened to `flatten-depth`, deeper nesting becomes JSON strings which you can parse with `parse_json()` if needed.
 
-**Variant mode** returns the entire response as a native Spark 4.0 VARIANT column with binary encoding:
+**Variant mode** returns the entire response as a native Spark VARIANT column with binary encoding:
 
 ```hocon
 schema {
@@ -347,7 +351,7 @@ SELECT
 FROM api.default.users;
 ```
 
-> **Note**: The colon syntax (`value:name::string`) shown in Databricks documentation is Databricks-specific. Open source Spark 4.0 uses `variant_get()` function.
+> **Note**: The colon syntax (`value:name::string`) shown in Databricks documentation is Databricks-specific. Open source Spark uses the `variant_get()` function.
 
 ### Streaming Response Formats
 
@@ -476,7 +480,7 @@ Spark Catalog ← Tables ← ScanBuilder (pushdown) → HTTP Client
 
 ## Stack
 
-- Scala 2.13 / Spark 4.0
+- Scala 2.13 / Spark 4.1
 - http4s-ember-client (HTTP)
 - circe (JSON) + circe-pointer (RFC 6901)
 - swagger-parser (OpenAPI)

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,8 @@ lazy val root = (project in file("."))
     name := "apilytics",
     libraryDependencies ++= Seq(
       // Spark
-      "org.apache.spark" %% "spark-sql"          % "4.0.0" % "provided",
-      "org.apache.spark" %% "spark-catalyst"      % "4.0.0" % "provided",
+      "org.apache.spark" %% "spark-sql"          % "4.1.3" % "provided",
+      "org.apache.spark" %% "spark-catalyst"      % "4.1.3" % "provided",
 
       // HTTP + JSON
       "org.http4s"       %% "http4s-ember-client" % "0.23.30",
@@ -39,9 +39,10 @@ lazy val root = (project in file("."))
       // OpenAPI
       "io.swagger.parser.v3" % "swagger-parser"   % "2.1.22",
 
-      // Arrow
-      "org.apache.arrow"  % "arrow-vector"        % "18.1.0",
-      "org.apache.arrow"  % "arrow-memory-netty"  % "18.1.0",
+      // Arrow — keep in lockstep with the version Spark bundles, since
+      // ArrowColumnVector hands our buffers straight to Spark's own Arrow.
+      "org.apache.arrow"  % "arrow-vector"        % "18.3.0",
+      "org.apache.arrow"  % "arrow-memory-netty"  % "18.3.0",
 
       // Config
       "com.typesafe"      % "config"              % "1.4.3",
@@ -59,7 +60,7 @@ lazy val root = (project in file("."))
     dependencyOverrides ++= Seq(
       // CVE-2026-54512/54513/54514/54515 (polymorphic type validator bypasses,
       // eager DNS resolution). Fixed in 2.18.8 / 2.18.9 — stay on the 2.18 line
-      // to match the Jackson that Spark 4.0.0 provides at runtime.
+      // to match the Jackson that Spark 4.1 provides at runtime.
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.9",
       // CVE-2025-66453 (DoS via Number.toFixed on crafted floats), reached
       // through json-schema-validator's ECMA-262 regex format checker.

--- a/docker/dist/Dockerfile
+++ b/docker/dist/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="Apilytics"
 LABEL org.opencontainers.image.source="https://github.com/Neutrinic/apilytics"
 LABEL org.opencontainers.image.description="Query REST APIs with Spark SQL"
 
-ARG SPARK_VERSION=4.0.0
+ARG SPARK_VERSION=4.1.3
 ARG JDK_VERSION=21
 
 # Install dependencies (including Python for PySpark)

--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 LABEL maintainer="APIlytics"
 
-ARG SPARK_VERSION=4.0.0
+ARG SPARK_VERSION=4.1.3
 ARG SCALA_VERSION=2.13
 ARG JDK_VERSION=21
 
@@ -34,7 +34,7 @@ ENV SPARK_SUBMIT_OPTS="$JAVA_OPTS"
 # For Almond/Scala kernel
 ENV JAVA_TOOL_OPTIONS="$JAVA_OPTS"
 
-# Download and install Spark 4.0 with Scala 2.13
+# Download and install Spark 4.1 with Scala 2.13
 RUN curl -L https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz | \
     tar -xz -C /opt && \
     ln -s /opt/spark-${SPARK_VERSION}-bin-hadoop3 ${SPARK_HOME}


### PR DESCRIPTION
Closes #34

## Summary

Moves the connector from Spark 4.0.0 to **Spark 4.1.3** (latest 4.1 patch). Spark 4.0.0 goes EOL on 2026-11-23, so this gets us onto a supported line; 4.1 is maintained through 2027-06-11.

This is the first of two planned bumps — 4.2.0 follows in a separate PR so any breakage is isolated per version.

- `build.sbt`: `spark-sql` / `spark-catalyst` 4.0.0 → 4.1.3 (still `provided`)
- `build.sbt`: Arrow 18.1.0 → **18.3.0**, matching what Spark 4.1 bundles. Worth keeping in lockstep since `ArrowColumnVector` hands our buffers straight to Spark's own Arrow.
- `docker/dist/Dockerfile`, `docker/spark/Dockerfile`: `SPARK_VERSION` 4.0.0 → 4.1.3
- `README.md`: badge, stack line, and a compatibility note

**No source changes were needed.** The Data Source V2 and Arrow columnar APIs we use are unchanged between 4.0 and 4.1, so the connector still runs on 4.0 clusters — Spark is a `provided` dep.

## Test plan
- [x] `sbt compile` — clean, no deprecation warnings (`-deprecation` is on)
- [x] `sbt test` — 328 tests pass (324 passed, 4 skipped, 3 ignored), no failures
- [x] `sbt assembly` — builds
- [x] Docker dist image builds on the Spark 4.1.3 base
- [x] End-to-end query through the Arrow columnar path: `SELECT name FROM api.default.pokemon LIMIT 3` returns real PokéAPI rows
- [x] VARIANT mode end-to-end (`variant_get`) against the 4.1 VARIANT GA implementation

## Notes for follow-up

- The runtime logs `WARN CheckAllocator: More than one DefaultAllocationManager on classpath` — our assembly bundles `arrow-memory-netty` and Spark ships its own. Pre-existing and benign (Arrow picks the first), but the bundled Arrow could arguably become `provided` too. Not changed here to keep this PR to the version bump.
- Issue #37 assumes Spark 4.1's chunked Arrow result streaming applies to our reader. In the 4.1 release notes that work sits under Spark Connect result delivery, not the Data Source V2 columnar path — worth confirming before starting that refactor. The lazy-batch rework in `RESTColumnarPartitionReader` still looks worth doing on its own merits.
- Issue #36 assumes `CREATE MATERIALIZED VIEW`; neither 4.1 nor 4.2 ships materialized views. 4.1's Real-Time Mode in Structured Streaming (SPARK-53736) is the realistic foundation there.