### PR TITLE
Make Arrow batch conversion lazy and fix Spark 4.1 regressions (#37, #185, #186)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,10 +58,13 @@ lazy val root = (project in file("."))
 
     // Security bumps for transitive deps pulled in by swagger-parser.
     dependencyOverrides ++= Seq(
-      // CVE-2026-54512/54513/54514/54515 (polymorphic type validator bypasses,
-      // eager DNS resolution). Fixed in 2.18.8 / 2.18.9 — stay on the 2.18 line
-      // to match the Jackson that Spark 4.1 provides at runtime.
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.9",
+      // CVE-2026-54512/54513/54514 (polymorphic type validator bypasses) are fixed
+      // in 2.21.4, CVE-2026-54515 in 2.21.5.
+      //
+      // Must stay on the 2.21 line: Spark 4.1 ships jackson-module-scala 2.21.x,
+      // which refuses to initialise against databind outside [2.21.0, 2.22.0) —
+      // pinning lower breaks Spark's own error machinery.
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.21.5",
       // CVE-2025-66453 (DoS via Number.toFixed on crafted floats), reached
       // through json-schema-validator's ECMA-262 regex format checker.
       // Fixed in 1.7.14.1 / 1.7.15.1 / 1.8.1.

--- a/src/main/scala/com/apilytics/core/config/Loader.scala
+++ b/src/main/scala/com/apilytics/core/config/Loader.scala
@@ -110,6 +110,13 @@ object Loader {
         case other           => throw new IllegalArgumentException(s"Unknown array handling: $other")
       } else ArrayHandling.KeepArray,
       arrowBatchSize = if (config.hasPath("arrow-batch-size")) config.getInt("arrow-batch-size") else 4096,
+      prefetchBatches = if (config.hasPath("prefetch-batches")) {
+        val n = config.getInt("prefetch-batches")
+        // Queue.bounded rejects a capacity below 1, and the failure would otherwise
+        // surface on an executor thread long after config load.
+        if (n < 1) throw new IllegalArgumentException(s"prefetch-batches must be >= 1, got: $n")
+        n
+      } else 2,
       explodeOuter = if (config.hasPath("explode-outer")) config.getBoolean("explode-outer") else false,
       mode = if (config.hasPath("mode")) config.getString("mode") match {
         case "strict"  => SchemaMode.Strict

--- a/src/main/scala/com/apilytics/core/config/Models.scala
+++ b/src/main/scala/com/apilytics/core/config/Models.scala
@@ -110,6 +110,13 @@ final case class SchemaConfig(
     flattenDepth: Int = 2,
     arrayHandling: ArrayHandling = ArrayHandling.KeepArray,
     arrowBatchSize: Int = 4096,
+    /** How many Arrow batches the reader may hold in flight ahead of Spark.
+      *
+      * Peak reader memory is roughly `prefetch-batches * arrow-batch-size` records,
+      * so this is the second half of the memory knob. Raising it trades memory for
+      * tolerance of slow/bursty APIs; 1 minimises memory at the cost of no overlap
+      * between fetching and consuming. Must be >= 1. */
+    prefetchBatches: Int = 2,
     /** When true, empty/null arrays emit one row with null element (OUTER semantics).
       * When false (default), empty arrays produce no rows (INNER semantics). */
     explodeOuter: Boolean = false,

--- a/src/main/scala/com/apilytics/spark/ExplodedArrayColumnarPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/ExplodedArrayColumnarPartitionReader.scala
@@ -19,6 +19,8 @@ class ExplodedArrayColumnarPartitionReader(partition: ExplodedArrayInputPartitio
   override protected val allocator: RootAllocator = new RootAllocator()
   override protected val arrowSchema: ArrowSchema = ArrowSchema.fromJSON(partition.arrowSchemaJson)
 
+  override protected def prefetchSize: Int = partition.sourceConfig.schema.prefetchBatches
+
   // Use singleton cache that persists across queries on this executor
   private val responseCache = ResponseCache.fromConfig(partition.sourceConfig.http.responseCache)
 
@@ -42,11 +44,12 @@ class ExplodedArrayColumnarPartitionReader(partition: ExplodedArrayInputPartitio
         )
         if (exploded.isEmpty) fs2.Stream.empty
         else {
-          val chunks = exploded.grouped(batchSize).toList
-          fs2.Stream.emits(chunks.map { chunk =>
+          // Convert in `map`, not inside `emits`, so batches are allocated as the
+          // bounded queue pulls them rather than all at once per page.
+          fs2.Stream.emits(exploded.grouped(batchSize).toList).unchunk.map { chunk =>
             val root = Converter.toArrow(chunk, arrowSchema, allocator)
             (arrowToBatch(root), root)
-          })
+          }
         }
       }
   }

--- a/src/main/scala/com/apilytics/spark/LazyColumnarReader.scala
+++ b/src/main/scala/com/apilytics/spark/LazyColumnarReader.scala
@@ -25,6 +25,12 @@ abstract class LazyColumnarReader extends PartitionReader[ColumnarBatch] {
   protected def arrowSchema: ArrowSchema
   protected def clientResource: Resource[IO, Client.RestClient]
   protected def buildStream(client: Client.RestClient): fs2.Stream[IO, (ColumnarBatch, VectorSchemaRoot)]
+
+  /** Batches held in flight ahead of Spark. Must be >= 1.
+    *
+    * Overrides read this from the partition's config, so keep it a `def` reading only
+    * constructor params — subclass `val`s are still unset when this base constructor runs.
+    */
   protected def prefetchSize: Int = 2
 
   // --- Lifecycle managed by this base class ---
@@ -69,6 +75,13 @@ abstract class LazyColumnarReader extends PartitionReader[ColumnarBatch] {
   }
 
   override def get(): ColumnarBatch = currentBatch
+
+  /** High-water mark of Arrow memory held by this reader, in bytes.
+    *
+    * Exposed so tests can assert the bounded-queue contract: peak tracks
+    * `prefetch-batches * arrow-batch-size`, not the size of the partition.
+    */
+  private[apilytics] def peakAllocatedBytes: Long = allocator.getPeakMemoryAllocation
 
   override def close(): Unit = {
     // 1. Cancel producer fiber (stops pagination mid-stream if needed)

--- a/src/main/scala/com/apilytics/spark/ParentChildColumnarPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/ParentChildColumnarPartitionReader.scala
@@ -35,6 +35,8 @@ class ParentChildColumnarPartitionReader(partition: ParentChildInputPartition)
   override protected lazy val allocator: RootAllocator = new RootAllocator()
   override protected lazy val arrowSchema: ArrowSchema = ArrowSchema.fromJSON(partition.arrowSchemaJson)
 
+  override protected def prefetchSize: Int = partition.sourceConfig.schema.prefetchBatches
+
   // Use lazy vals to avoid initialization order issues with LazyColumnarReader's constructor
   // which starts a fiber that may access these before they're initialized
   private lazy val responseCache = ResponseCache.fromConfig(partition.sourceConfig.http.responseCache)
@@ -114,11 +116,12 @@ class ParentChildColumnarPartitionReader(partition: ParentChildInputPartition)
               val enrichedRecords = childRecords.map { childRecord =>
                 ParentChildUtils.enrichChildRecord(childRecord, parentKeyJson.get, partition.parentKeyColumn)
               }
-              val chunks = enrichedRecords.grouped(batchSize).toList
-              fs2.Stream.emits(chunks.map { chunk =>
+              // Convert in `map`, not inside `emits`, so batches are allocated as the
+              // bounded queue pulls them rather than all at once per page.
+              fs2.Stream.emits(enrichedRecords.grouped(batchSize).toList).unchunk.map { chunk =>
                 val root = Converter.toArrow(chunk, arrowSchema, allocator)
                 (arrowToBatch(root), root)
-              })
+              }
             }
           }
       }
@@ -194,11 +197,12 @@ class ParentChildColumnarPartitionReader(partition: ParentChildInputPartition)
 
             if (enrichedRecords.isEmpty) fs2.Stream.empty
             else {
-              val chunks = enrichedRecords.grouped(arrowBatchSize).toList
-              fs2.Stream.emits(chunks.map { chunk =>
+              // Convert in `map`, not inside `emits`, so batches are allocated as the
+              // bounded queue pulls them rather than all at once per batch-join round.
+              fs2.Stream.emits(enrichedRecords.grouped(arrowBatchSize).toList).unchunk.map { chunk =>
                 val root = Converter.toArrow(chunk, arrowSchema, allocator)
                 (arrowToBatch(root), root)
-              })
+              }
             }
           }
         }

--- a/src/main/scala/com/apilytics/spark/RESTColumnarPartitionReader.scala
+++ b/src/main/scala/com/apilytics/spark/RESTColumnarPartitionReader.scala
@@ -31,6 +31,8 @@ class RESTColumnarPartitionReader(partition: RESTInputPartition) extends LazyCol
   override protected val allocator: RootAllocator = new RootAllocator()
   override protected val arrowSchema: ArrowSchema = ArrowSchema.fromJSON(partition.arrowSchemaJson)
 
+  override protected def prefetchSize: Int = partition.sourceConfig.schema.prefetchBatches
+
   // Use lazy vals to avoid initialization order issues with LazyColumnarReader's constructor
   // which starts a fiber that may access these before they're initialized
   private lazy val responseCache = ResponseCache.fromConfig(partition.sourceConfig.http.responseCache)
@@ -41,14 +43,18 @@ class RESTColumnarPartitionReader(partition: RESTInputPartition) extends LazyCol
     case None    => partition.sourceConfig.http
   }
 
-  // Use Spark's Hadoop config for S3/HDFS credential resolution via core-site.xml
+  // Use Spark's Hadoop config for S3/HDFS credential resolution via core-site.xml.
+  //
+  // Executors normally have no active session, so the fallback is the common path,
+  // not an edge case. Ask via getActiveSession/getDefaultSession rather than
+  // SparkSession.active: `active` throws when there is no session, and the type it
+  // throws changed in Spark 4.1 (IllegalStateException -> SparkException), which
+  // silently defeated the previous try/catch.
   private lazy val checkpointStore: CheckpointStore = {
-    val hadoopConf = try {
-      SparkSession.active.sparkContext.hadoopConfiguration
-    } catch {
-      case _: IllegalStateException =>
-        new org.apache.hadoop.conf.Configuration()
-    }
+    val hadoopConf = SparkSession.getActiveSession
+      .orElse(SparkSession.getDefaultSession)
+      .map(_.sparkContext.hadoopConfiguration)
+      .getOrElse(new org.apache.hadoop.conf.Configuration())
     CheckpointStore.fromConfig(partition.checkpointConfig, hadoopConf)
   }
 
@@ -107,18 +113,17 @@ class RESTColumnarPartitionReader(partition: RESTInputPartition) extends LazyCol
             if (records.isEmpty) Stream.eval(updateState).drain
             else {
               Stream.eval(updateState) >>
-              Stream.emits {
-                val chunks = records.grouped(batchSize).toList
+              // Emit the chunks first and convert in `map`, so each Arrow root is
+              // built only when the bounded queue pulls it. Converting inside
+              // `Stream.emits` would allocate every batch in the page up front and
+              // make peak memory track page size instead of arrow-batch-size.
+              Stream.emits(records.grouped(batchSize).toList).unchunk.map { chunk =>
                 partition.schemaMode match {
                   case SchemaMode.Variant =>
-                    chunks.map { chunk =>
-                      (VariantBatch.fromRecords(chunk), null: VectorSchemaRoot)
-                    }
+                    (VariantBatch.fromRecords(chunk), null: VectorSchemaRoot)
                   case _ =>
-                    chunks.map { chunk =>
-                      val root = Converter.toArrow(chunk, arrowSchema, allocator)
-                      (arrowToBatch(root), root)
-                    }
+                    val root = Converter.toArrow(chunk, arrowSchema, allocator)
+                    (arrowToBatch(root), root)
                 }
               }
             }

--- a/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
+++ b/src/test/scala/com/apilytics/core/config/LoaderSuite.scala
@@ -142,6 +142,48 @@ class LoaderSuite extends FunSuite {
     assertEquals(result.schema.arrowBatchSize, 1024)
   }
 
+  test("prefetch-batches defaults to 2") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    assertEquals(result.schema.prefetchBatches, 2)
+  }
+
+  test("prefetch-batches can be configured") {
+    val config = ConfigFactory.parseString(
+      """
+        |openapi = "spec.json"
+        |auth { type = bearer, token = "t" }
+        |schema {
+        |  prefetch-batches = 8
+        |}
+        |""".stripMargin)
+
+    val result = Loader.load(config)
+    assertEquals(result.schema.prefetchBatches, 8)
+  }
+
+  test("prefetch-batches below 1 is rejected at load time") {
+    def withPrefetch(n: Int) = ConfigFactory.parseString(
+      s"""
+         |openapi = "spec.json"
+         |auth { type = bearer, token = "t" }
+         |schema {
+         |  prefetch-batches = $n
+         |}
+         |""".stripMargin)
+
+    // Queue.bounded would otherwise fail on an executor thread, far from the cause.
+    List(0, -1).foreach { n =>
+      val ex = intercept[IllegalArgumentException](Loader.load(withPrefetch(n)))
+      assert(ex.getMessage.contains("prefetch-batches must be >= 1"), ex.getMessage)
+    }
+  }
+
   test("results-path and max-pages default values") {
     val config = ConfigFactory.parseString(
       """

--- a/src/test/scala/com/apilytics/spark/JacksonCompatibilitySuite.scala
+++ b/src/test/scala/com/apilytics/spark/JacksonCompatibilitySuite.scala
@@ -1,0 +1,27 @@
+package com.apilytics.spark
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import munit.FunSuite
+
+/** Guards the coupling between our jackson-databind pin and Spark's Jackson line.
+  *
+  * `build.sbt` pins jackson-databind via `dependencyOverrides` to stay ahead of CVEs.
+  * Spark ships its own jackson-module-scala, which validates the databind version at
+  * registration time and refuses anything outside a narrow range. Pin below that range
+  * and `ErrorClassesJsonReader` dies on class-init, taking all Spark error construction
+  * with it (see #185).
+  *
+  * That failure is invisible to the rest of the suite — nothing else registers the Scala
+  * module — so without this test a bad pin ships green. Re-check on every Spark upgrade:
+  * the pin has to track Spark's Jackson line, not just the CVE floor.
+  */
+class JacksonCompatibilitySuite extends FunSuite {
+
+  test("jackson-databind pin satisfies Spark's jackson-module-scala version range") {
+    // Exactly what Spark's ErrorClassesJsonReader does on init. Throws
+    // JsonMappingException("Scala module X requires Jackson Databind version >= ...")
+    // when the versions have drifted apart.
+    new ObjectMapper().registerModule(DefaultScalaModule)
+  }
+}

--- a/src/test/scala/com/apilytics/spark/LazyColumnarReaderMemorySuite.scala
+++ b/src/test/scala/com/apilytics/spark/LazyColumnarReaderMemorySuite.scala
@@ -1,0 +1,176 @@
+package com.apilytics.spark
+
+import com.apilytics.core.config._
+import com.apilytics.core.openapi.{Endpoint, OpenAPISchema}
+import com.apilytics.core.schema.SchemaMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import munit.FunSuite
+
+import scala.concurrent.duration._
+
+/** Memory characteristics of the lazy columnar reader.
+  *
+  * `LazyColumnarReader` streams Arrow batches through a bounded queue, so peak
+  * memory is meant to track `prefetch-batches * arrow-batch-size` rather than the
+  * total size of the partition. These tests pin that contract down by measuring
+  * the Arrow allocator's high-water mark while reading partitions of very
+  * different sizes.
+  */
+class LazyColumnarReaderMemorySuite extends FunSuite {
+
+  private var server: WireMockServer = _
+
+  // Response caching is off by default, so repeated reads in a test really re-fetch.
+  override def beforeEach(context: BeforeEach): Unit = {
+    server = new WireMockServer(wireMockConfig().dynamicPort())
+    server.start()
+  }
+
+  override def afterEach(context: AfterEach): Unit = server.stop()
+
+  private val recordSchema = OpenAPISchema.ObjectType(
+    Map(
+      "id"      -> OpenAPISchema.IntegerType(),
+      "name"    -> OpenAPISchema.StringType(),
+      "payload" -> OpenAPISchema.StringType()
+    )
+  )
+
+  private val endpoint = Endpoint(
+    path = "/items",
+    operationId = Some("listItems"),
+    responseSchema = recordSchema,
+    queryParams = Nil
+  )
+
+  /** Serve `pages` pages of `perPage` records via offset pagination, then an empty page. */
+  private def stubPages(pages: Int, perPage: Int): Unit = {
+    // Each record carries a chunky payload so Arrow allocation is easy to see.
+    val filler = "x" * 512
+
+    (0 until pages).foreach { page =>
+      val offset = page * perPage
+      val records = (0 until perPage).map { i =>
+        s"""{"id": ${offset + i}, "name": "item-${offset + i}", "payload": "$filler"}"""
+      }
+      server.stubFor(
+        get(urlPathEqualTo("/items"))
+          .withQueryParam("offset", equalTo(offset.toString))
+          .willReturn(okJson(s"""{"results": [${records.mkString(",")}]}"""))
+      )
+    }
+
+    // Terminal empty page stops offset pagination.
+    server.stubFor(
+      get(urlPathEqualTo("/items"))
+        .withQueryParam("offset", equalTo((pages * perPage).toString))
+        .willReturn(okJson("""{"results": []}"""))
+    )
+  }
+
+  private def partitionFor(batchSize: Int, prefetch: Int, perPage: Int): RESTInputPartition = {
+    val sourceConfig = SourceConfig(
+      openapi = "test.yaml",
+      auth = AuthConfig(
+        authType = AuthType.Header,
+        headerName = Some("Accept"),
+        headerValue = Some("application/json")
+      ),
+      pagination = PaginationConfig(
+        style = PaginationStyle.Offset,
+        offsetParam = Some("offset"),
+        pageSizeParam = Some("limit"),
+        maxPageSize = perPage,
+        resultsPath = Some("/results")
+      ),
+      schema = SchemaConfig(arrowBatchSize = batchSize, prefetchBatches = prefetch),
+      http = HttpConfig(maxRetries = 0, maxBackoff = 1.second, timeout = 10.seconds)
+    )
+
+    RESTInputPartition(
+      endpoint = endpoint,
+      tableConfig = Some(TableConfig(endpoint = "/items", dataPath = Some("/results"))),
+      sourceConfig = sourceConfig,
+      baseUrl = s"http://localhost:${server.port()}",
+      arrowSchemaJson = SchemaMapper.toArrowSchema(recordSchema).toJson,
+      pushedParams = Map.empty,
+      pushedLimit = None
+    )
+  }
+
+  /** Read the partition to exhaustion, returning (rows read, peak Arrow bytes).
+    *
+    * `perBatchDelay` slows the consumer so the producer runs ahead and actually
+    * fills the queue — prefetch is an upper bound, so it only shows up in the
+    * high-water mark when Spark is the slower side.
+    */
+  private def readAll(partition: RESTInputPartition, perBatchDelay: Duration = Duration.Zero): (Int, Long) = {
+    val reader = new RESTColumnarPartitionReader(partition)
+    try {
+      var rows = 0
+      while (reader.next()) {
+        rows += reader.get().numRows()
+        if (perBatchDelay > Duration.Zero) Thread.sleep(perBatchDelay.toMillis)
+      }
+      (rows, reader.peakAllocatedBytes)
+    } finally reader.close()
+  }
+
+  test("peak memory tracks batch size, not total records") {
+    val batchSize = 256
+    val perPage = 256
+
+    stubPages(pages = 1, perPage = perPage)
+    val (smallRows, smallPeak) = readAll(partitionFor(batchSize, prefetch = 2, perPage))
+
+    server.resetAll()
+    stubPages(pages = 20, perPage = perPage)
+    val (largeRows, largePeak) = readAll(partitionFor(batchSize, prefetch = 2, perPage))
+
+    assertEquals(smallRows, perPage)
+    assertEquals(largeRows, perPage * 20, "must actually read every page")
+
+    // 20x the data. If batches were materialised eagerly this would grow ~20x;
+    // with the bounded queue only prefetch+in-flight batches are ever live.
+    assert(
+      largePeak <= smallPeak * 2,
+      s"peak grew with partition size: $smallPeak bytes for $smallRows rows vs $largePeak bytes for $largeRows rows"
+    )
+  }
+
+  test("peak memory scales with arrow-batch-size") {
+    val perPage = 512
+    stubPages(pages = 8, perPage = perPage)
+
+    val (smallRows, smallPeak) = readAll(partitionFor(batchSize = 64, prefetch = 2, perPage))
+    val (largeRows, largePeak) = readAll(partitionFor(batchSize = 512, prefetch = 2, perPage))
+
+    assertEquals(smallRows, largeRows, "both runs must read the same data")
+
+    // Guards against the bound above being vacuous: if peak were independent of
+    // batch size, it would not be tracking live batches at all.
+    assert(
+      largePeak > smallPeak,
+      s"arrow-batch-size had no effect on peak memory: 64 -> $smallPeak bytes, 512 -> $largePeak bytes"
+    )
+  }
+
+  test("prefetch-batches raises the in-flight ceiling when the consumer lags") {
+    val batchSize = 256
+    val perPage = 256
+    stubPages(pages = 12, perPage = perPage)
+
+    // Prefetch is an upper bound, so it only becomes observable when Spark consumes
+    // slower than the API delivers. Without the delay both runs sit at one live batch.
+    val delay = 25.millis
+    val (_, tightPeak) = readAll(partitionFor(batchSize, prefetch = 1, perPage), delay)
+    val (_, loosePeak) = readAll(partitionFor(batchSize, prefetch = 8, perPage), delay)
+
+    assert(
+      loosePeak > tightPeak,
+      s"prefetch-batches had no effect on peak memory: prefetch=1 -> $tightPeak bytes, prefetch=8 -> $loosePeak bytes"
+    )
+  }
+}


### PR DESCRIPTION
Closes #37
Closes #185
Closes #186

Three entangled changes: the benchmark that #37 asked for is what surfaced #185 and #186, and #37's tests cannot pass without both fixes.

## #37 — Arrow conversion was not actually lazy

The bounded-queue reader landed in #66/#68 two days after #37 was filed, so the issue's "Current Behavior" snippet is long gone. But writing the benchmark showed the acceptance criterion was only half met.

Every columnar reader did this:

```scala
Stream.emits(chunks.map { chunk => Converter.toArrow(chunk, ...) })
```

That converts **every chunk of a page** to Arrow before a single batch reaches the queue, so peak memory tracked page size and `arrow-batch-size` had no downward effect at all. Moving conversion into `map` isn't enough either — fs2's `map` is chunk-wise and `Stream.emits` yields one Chunk — so `unchunk` is needed to get true per-batch laziness:

```scala
Stream.emits(chunks).unchunk.map { chunk => Converter.toArrow(chunk, ...) }
```

Fixed at all four sites (`RESTColumnarPartitionReader`, `ExplodedArrayColumnarPartitionReader`, and both join strategies in `ParentChildColumnarPartitionReader`).

**Benchmark** — 4096 rows over 8 pages of 512, peak Arrow allocator bytes:

| `arrow-batch-size` | before | after | change |
|---|---|---|---|
| 64 | 1,032,192 | 311,296 | **-70%** |
| 128 | — | 327,680 | |
| 256 | 491,520 | 491,520 | unchanged |
| 512 | 819,200 | 819,200 | unchanged |

Before, peak was *inverted* — smaller batches cost more memory. After, it scales monotonically. The win lands where `arrow-batch-size` < page size, which is exactly when someone is deliberately capping memory; at or above page size there is nothing left to defer, hence unchanged.

Also adds **`schema.prefetch-batches`** (default 2, was hardcoded), validated `>= 1` at config load so a bad value fails there rather than inside `Queue.bounded` on an executor. Peak reader memory is now `prefetch-batches * arrow-batch-size`, both configurable.

## #185 — jackson-databind pin broke Spark 4.1

The 2.18.9 override from #181 is rejected outright by Spark 4.1's `jackson-module-scala 2.21.2` (`requires >= 2.21.0 and < 2.22.0`), which blows up `ErrorClassesJsonReader` and therefore all Spark error construction. Moved to **2.21.5**, which still carries the fixes for CVE-2026-54512/54513/54514 (2.21.4) and CVE-2026-54515 (2.21.5).

**This was silently unguarded.** Reverting the pin to 2.18.9 on this branch leaves all 334 tests green — nothing else in the suite registers the Scala module. The #186 fix below makes that worse, since switching off `SparkSession.active` removes the one path that happened to trip it. So this PR adds `JacksonCompatibilitySuite`, which registers `DefaultScalaModule` exactly the way Spark's `ErrorClassesJsonReader` does. Verified in both directions: fails on 2.18.9 with the real error message, passes on 2.21.5.

Checked ahead: Spark 4.2.0 also uses Jackson 2.21.2, so 2.21.5 carries through the 4.2 bump unchanged.

## #186 — checkpoint store crashed on executors

`SparkSession.active` throws `SparkException` in 4.1 where 4.0 threw `IllegalStateException`, so the `catch IllegalStateException` fallback was dead. Executors normally have no active session, so this was the common path on a real cluster — local mode masked it. Now uses `getActiveSession.orElse(getDefaultSession)`, which returns `Option` and doesn't depend on Spark's exception type.

## Test plan
- [x] `sbt test` — **335 pass** (was 328), 0 failures
- [x] New `LazyColumnarReaderMemorySuite`: peak tracks batch size not total records (20x data, peak flat); peak scales with `arrow-batch-size`; `prefetch-batches` raises the in-flight ceiling when the consumer lags
- [x] New `JacksonCompatibilitySuite` — verified it fails on the broken pin and passes on the fixed one
- [x] New `LoaderSuite` cases for `prefetch-batches` default / override / `< 1` rejection
- [x] `sbt assembly` builds
- [x] Docker dist image end-to-end on Spark 4.1.3 with jackson 2.21.5 bundled — real PokéAPI query returns rows
- [x] CI green
- [ ] `Security` workflow (2.21.5 should keep the OWASP check green)

## Notes
- `LazyColumnarReader.peakAllocatedBytes` is a `private[apilytics]` test seam so the memory contract can be asserted rather than assumed.